### PR TITLE
Set `connectionType` to `false` by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Options:
   --block <substrings...>       A comma-delimited list of urls to block (based on a substring match) (default: [])
   --firefoxPrefs <object>       Any Firefox User Preferences to apply (Firefox only)
   --cpuThrottle <int>           CPU throttling factor
-  --connectionType <string>     Network connection type. (choices: "cable", "dls", "4g", "3g", "3gfast", "3gslow", "2g", "fios", default: "4g")
+  --connectionType <string>     Network connection type. By default, no throttling is applied. (choices: "cable", "dls", "4g", "3g", "3gfast", "3gslow", "2g", "fios", default: false)
   --width <int>                 Viewport width, in pixels (default: "1366")
   --height <int>                Viewport height, in pixels (default: "768")
   --frameRate <int>             Filmstrip frame rate, in frames per second (default: 1)

--- a/index.js
+++ b/index.js
@@ -58,7 +58,7 @@ export default function browserAgent() {
     .addOption(new Option('--cpuThrottle <int>', 'CPU throttling factor'))
     .addOption(
       new Option('--connectionType <string>', 'Network connection type')
-        .default('4g')
+        .default(false)
         .choices([
           'cable',
           'dls',

--- a/lib/testRunner.js
+++ b/lib/testRunner.js
@@ -318,10 +318,14 @@ class TestRunner {
     return lcpEvents;
   }
   async throttleNetwork() {
+    // Only apply throttling if connectionType is explicitly set
+    if (!this.options.connectionType) {
+      log('No network throttling applied');
+      return;
+    }
+
     let start = performance.now();
-    let networkType = this.options.connectionType
-      ? this.options.connectionType
-      : '4g';
+    let networkType = this.options.connectionType;
 
     try {
       //TODO: Remove monkey patch in throttle (currently setting dummynet any to any)
@@ -411,8 +415,11 @@ class TestRunner {
    */
   async postProcess() {
     try {
-      await throttleStop();
-      log('Throttling successfully stopped');
+      // Only stop throttling if it was actually started
+      if (this.options.connectionType) {
+        await throttleStop();
+        log('Throttling successfully stopped');
+      }
     } catch (error) {
       console.error('throttling error: ' + error);
     }


### PR DESCRIPTION
This closes #5 by defaulting connectionType to false.

It also makes sure to check if a `connectionType` was set before trying to stop throttling, removing the need for a privileged user by default.