### PR TITLE
Fixes a bug caused by not being consistent in referencing err vs error

### DIFF
--- a/lib/testRunner.js
+++ b/lib/testRunner.js
@@ -369,8 +369,8 @@ class TestRunner {
                 frame_rate: frameRate,
                 file_name: 'frame_%s',
               },
-              function (error, files) {
-                if (error) {
+              function (err, files) {
+                if (err) {
                   console.error('Error generating filmstrip frames:', err);
                   reject(err);
                 } else {


### PR DESCRIPTION
We had a bug caused by using `error` and `err` inconsistently when handling errors for generating our filmstrip frames.

This fixes that.