### PR TITLE
feat: add option to automatically open HTML reports in browser

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Options:
   --auth <object>               Basic HTTP authentication (Expects: {"username": "", "password": ""})  (default: false)
   --timeout <int>               Maximum time (in milliseconds) to wait for test to complete (default: 30000)
   --html                        Generate HTML report (default: false)
-  --open-html                   Open HTML report in browser (requires --html) (default: false)
+  --openHtml                    Open HTML report in browser (requires --html) (default: false)
   --list                        Generate a list of test results as HTML (default: false)
   --help                        display help for command
 ```
@@ -61,18 +61,18 @@ npx . -u https://www.example.com -b chrome --timeout 50000
 ✅ Safari
 ✅ Firefox
 
-You can generate an HTML report of your test results by passing the `--html` parameter. To automatically open the report in your default browser after generation, add the `--open-html` flag.
+You can generate an HTML report of your test results by passing the `--html` parameter. To automatically open the report in your default browser after generation, add the `--openHtml` flag.
 
 #### Generate HTML report
 
 ```
-npx . -u https://timkadlec.com -b chrome --html
+npx . -u https://example.com -b chrome --html
 ```
 
 #### Generate and automatically open HTML report
 
 ```
-npx . -u https://timkadlec.com -b chrome --html --open-html
+npx . -u https://example.com -b chrome --html --openHtml
 ```
 
 ### Setting Custom Cookies

--- a/index.js
+++ b/index.js
@@ -31,6 +31,7 @@ import { DEFAULT_OPTIONS } from './lib/defaultOptions.js';
  * @property {import('playwright').HTTPCredentials=} auth
  * @property {number=} timeout
  * @property {boolean=} html
+ * @property {boolean=} openHtml
  * @property {boolean=} list
  */
 
@@ -250,9 +251,9 @@ export default function browserAgent() {
     )
     .addOption(
       new Option(
-        '--open-html',
+        '--openHtml',
         'Open HTML report in browser (requires --html)',
-      ).default(DEFAULT_OPTIONS.open_html),
+      ).default(DEFAULT_OPTIONS.openHtml),
     )
     .addOption(
       new Option('--list', 'Generate list of results in HTML').default(

--- a/lib/config.js
+++ b/lib/config.js
@@ -21,6 +21,7 @@ export function normalizeCLIConfig(options) {
     disableJS: options.disableJS || DEFAULT_OPTIONS.disableJS,
     debug: options.debug || DEFAULT_OPTIONS.debug,
     html: options.html || DEFAULT_OPTIONS.html,
+    openHtml: options.openHtml || DEFAULT_OPTIONS.openHtml,
     list: options.list || DEFAULT_OPTIONS.list,
     connectionType: options.connectionType || DEFAULT_OPTIONS.connectionType,
     auth: options.auth || DEFAULT_OPTIONS.auth,

--- a/lib/defaultOptions.js
+++ b/lib/defaultOptions.js
@@ -23,6 +23,8 @@ export const DEFAULT_OPTIONS = {
   debug: false,
   // Generate HTML report
   html: false,
+  // Open HTML report in browser
+  openHtml: false,
   // Generate list of results in HTML
   list: false,
   // Network throttling type (false = no throttling)

--- a/lib/testRunner.js
+++ b/lib/testRunner.js
@@ -493,7 +493,7 @@ class TestRunner {
         const htmlPath = this.paths['results'] + '/index.html';
         writeFileSync(htmlPath, testHTML, 'utf8');
 
-        // Open the HTML report in the browser if --open-html is set
+        // Open the HTML report in the browser if --openHtml is set
         if (this.options.openHtml) {
           this.openInBrowser(path.resolve(htmlPath));
         }
@@ -619,18 +619,18 @@ class TestRunner {
    * Opens a file in the default browser
    */
   openInBrowser(filePath) {
-    const command =
-      process.platform === 'darwin'
-        ? `open "${filePath}"`
-        : process.platform === 'win32'
-          ? `start "" "${filePath}"`
-          : `xdg-open "${filePath}"`;
+    let command = '';
+    if (process.platform === 'darwin') {
+      command = `open "${filePath}"`;
+    } else if (process.platform === 'win32') {
+      command = `start "" "${filePath}"`;
+    } else {
+      command = `xdg-open "${filePath}"`;
+    }
 
-    exec(command, err => {
+    exec(command, (err) => {
       if (err) {
         console.error('Error opening HTML report:', err);
-      } else {
-        log(`Opened HTML report in browser: ${filePath}`);
       }
     });
   }


### PR DESCRIPTION
- Add `--open-html` CLI option that opens generated HTML reports in the default browser
- Add HTML report generation documentation to the README