### PR TITLE
Fix the playwright dependency version mismatch

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
         "telescope": "cli.js"
       },
       "devDependencies": {
-        "@playwright/test": "^1.29.2",
+        "@playwright/test": "next",
         "jest": "^29.5.0",
         "prettier": "^3.6.2",
         "prettier-plugin-ejs": "^1.0.3"
@@ -837,59 +837,16 @@
       }
     },
     "node_modules/@playwright/test": {
-      "version": "1.55.1",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.55.1.tgz",
-      "integrity": "sha512-IVAh/nOJaw6W9g+RJVlIQJ6gSiER+ae6mKQ5CX1bERzQgbC1VSeBlwdvczT7pxb0GWiyrxH4TGKbMfDb4Sq/ig==",
+      "version": "1.57.0-alpha-2025-11-02",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.57.0-alpha-2025-11-02.tgz",
+      "integrity": "sha512-sGzxhgebUNnpnmQ+7wFEX+rAzXIAEISGJgYn/9nWbH9tzAc2KsJvspwZYDbmgXATb/+cdJD8/0+iU8vyiJ2jgA==",
       "dev": true,
+      "license": "Apache-2.0",
       "dependencies": {
-        "playwright": "1.55.1"
+        "playwright": "1.57.0-alpha-2025-11-02"
       },
       "bin": {
         "playwright": "cli.js"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@playwright/test/node_modules/fsevents": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
-      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-      "dev": true,
-      "hasInstallScript": true,
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
-      }
-    },
-    "node_modules/@playwright/test/node_modules/playwright": {
-      "version": "1.55.1",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.55.1.tgz",
-      "integrity": "sha512-cJW4Xd/G3v5ovXtJJ52MAOclqeac9S/aGGgRzLabuF8TnIb6xHvMzKIa6JmrRzUkeXJgfL1MhukP0NK6l39h3A==",
-      "dev": true,
-      "dependencies": {
-        "playwright-core": "1.55.1"
-      },
-      "bin": {
-        "playwright": "cli.js"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "optionalDependencies": {
-        "fsevents": "2.3.2"
-      }
-    },
-    "node_modules/@playwright/test/node_modules/playwright-core": {
-      "version": "1.55.1",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.55.1.tgz",
-      "integrity": "sha512-Z6Mh9mkwX+zxSlHqdr5AOcJnfp+xUWLCt9uKV18fhzA8eyxUd8NUWzAjxUh55RZKSYwDGX0cfaySdhZJGMoJ+w==",
-      "dev": true,
-      "bin": {
-        "playwright-core": "cli.js"
       },
       "engines": {
         "node": ">=18"
@@ -3031,11 +2988,12 @@
       }
     },
     "node_modules/playwright": {
-      "version": "1.57.0-alpha-2025-10-24",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.57.0-alpha-2025-10-24.tgz",
-      "integrity": "sha512-h7BK38U0t7ylKUftTHaL8erydzhwSstQco24OuEtoYS0xX67QHwc9fEQW2x6Rmnd8vT0RuD9ePuP3lDl2AmPDQ==",
+      "version": "1.57.0-alpha-2025-11-02",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.57.0-alpha-2025-11-02.tgz",
+      "integrity": "sha512-0Ce/0oeN/I9ej/8DA1inYQe3xOfoUYtA4knKwCrYlZMSkxzr+PL/KGNXAAvT0CTYsLSXN+NNsBZobKTSCXgviA==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "playwright-core": "1.57.0-alpha-2025-10-24"
+        "playwright-core": "1.57.0-alpha-2025-11-02"
       },
       "bin": {
         "playwright": "cli.js"
@@ -3087,9 +3045,10 @@
       }
     },
     "node_modules/playwright/node_modules/playwright-core": {
-      "version": "1.57.0-alpha-2025-10-24",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.57.0-alpha-2025-10-24.tgz",
-      "integrity": "sha512-OXTMR6QjnUleUYLmEsZcKEvTaxik+6WEJgr6JXNxrD8DleV5U8+Hv5A1EDUfq3SpvUKstBnJEJwX7lyLHUKD2Q==",
+      "version": "1.57.0-alpha-2025-11-02",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.57.0-alpha-2025-11-02.tgz",
+      "integrity": "sha512-O2J16IPALIZj/P5wOWivaOfdVnPYNezlvcbDpUuSE7NGVkxJVmuQte/QaDcZtYEXZLkmR3QreS8kkPlihz4pVQ==",
+      "license": "Apache-2.0",
       "bin": {
         "playwright-core": "cli.js"
       },

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "postinstall": "npx playwright install"
   },
   "devDependencies": {
-    "@playwright/test": "^1.29.2",
+    "@playwright/test": "next",
     "jest": "^29.5.0",
     "prettier": "^3.6.2",
     "prettier-plugin-ejs": "^1.0.3"


### PR DESCRIPTION
This fixes #24.

It was disallowing us to run it with Firefox and Safari because @playwright/test also adds the "playwright" from its dependencies to the node_modules/.bin/ directory. That's was shadowing the playwright that was added as the main dependency when `npx playwright install` was run during the `postinstall` script execution. This was creating a mismatch on the downloaded Firefox/Safari vs the Firefox/Safari the `next` version wanted to run.