### PR TITLE
fix: Close connection on timeout

### DIFF
--- a/lib/testRunner.js
+++ b/lib/testRunner.js
@@ -173,7 +173,16 @@ class TestRunner {
    * Triggers the navigation based on the passed in url, grabs a screenshot, and closes the context and browser
    */
   async doNavigation() {
-    await this.page.goto(this.testURL, { waitUntil: 'networkidle' });
+    try {
+      await this.page.goto(this.testURL, { waitUntil: 'networkidle' });
+    } catch (err) {
+      // If navigation timed out, set the context offline and continue.
+      if (err && (err.name === 'TimeoutError' || /Timeout/.test(err.message))) {
+        await this.page.context().setOffline(true);
+      } else {
+        throw err;
+      }
+    }
     // grab our screenshot
     await this.page.screenshot({
       path: this.paths['results'] + '/screenshot.png',


### PR DESCRIPTION
https://github.com/cloudflare/telescope/issues/32

This could address websites that still keeps an open connection when `page.goto()` reaches its **timeout**(quite often if used with `{ waitUntil: 'networkidle' }`); also retroactively stops all connections by setting the browser context to offline.
