### PR TITLE
feat: export `launch` for programmatic usage

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,8 +12,9 @@ import { DEFAULT_OPTIONS } from './lib/defaultOptions.js';
  * Internal function that handles the core test execution flow.
  * Normalizes options, creates browser instance, runs test, and ensures cleanup.
  *
- * @param {Object} options - Test options (raw from CLI or programmatic use)
- * @returns {Promise<{success: boolean, testId: string, resultsPath: string}>} Test result with ID and results path
+ * @param {LaunchOptions} options - Test options (raw from CLI or programmatic use)
+ * @returns {SuccessfulTestResult} Test result with ID and results path
+ * @throws {Error} If the test fails
  * @private
  */
 async function executeTest(options) {

--- a/lib/launch.js
+++ b/lib/launch.js
@@ -1,0 +1,64 @@
+import { BrowserConfig } from './browsers.js';
+import { TestRunner } from './testRunner.js';
+import { ChromeRunner } from './chromeRunner.js';
+
+/**
+ * @typedef {Parameters<import('playwright').BrowserContext['addCookies']>[0][number]} Cookie
+ */
+
+/**
+ * @typedef {Object} LaunchOptions
+ * @property {string} url
+ * @property {string} browser
+ * @property {Record<string, string>=} headers
+ * @property {Cookie|Array<Cookie>=} cookies
+ * @property {string[]=} args
+ * @property {string[]=} blockDomains
+ * @property {string[]=} block
+ * @property {Record<string, unknown>=} firefoxPrefs
+ * @property {number=} cpuThrottle
+ * @property {keyof typeof import('./connectivity.js').networkTypes=} connectionType
+ * @property {number=} width
+ * @property {number=} height
+ * @property {number=} frameRate
+ * @property {boolean=} disableJS
+ * @property {boolean=} debug
+ * @property {import('playwright').HTTPCredentials=} auth
+ * @property {number=} timeout
+ * @property {boolean=} html
+ * @property {boolean=} list
+ */
+
+/**
+ * @param {LaunchOptions} options
+ * @param {BrowserConfig} browserConfig
+ * @returns {TestRunner|ChromeRunner}
+ */
+function getRunner(options, browserConfig) {
+  if (browserConfig.engine === 'chromium') {
+    return new ChromeRunner(options, browserConfig);
+  } else {
+    return new TestRunner(options, browserConfig);
+  }
+}
+
+/**
+ * Launches a browser instance with the specified options.
+ * @param {LaunchOptions} options - The launch options.
+ */
+export async function launch(options) {
+  if (options.flags) {
+    options.args = options.flags.split(',');
+  }
+
+  const browserConfig = new BrowserConfig().getBrowserConfig(
+    options.browser,
+    options,
+  );
+
+  const Runner = getRunner(options, browserConfig);
+
+  await Runner.setupTest();
+  await Runner.doNavigation();
+  await Runner.postProcess();
+}


### PR DESCRIPTION
This exports `launch` - a function which takes `LaunchOptions` and runs the browser the same way the CLI does.

The CLI now calls `launch` internally with normalized options.

This means the various CLI arg normalizations (e.g. parsing cookie objects) happen only in the CLI, while the underlying code expects a strong type.