### PR TITLE
Adding CLI command to config.json

### DIFF
--- a/index.js
+++ b/index.js
@@ -301,7 +301,7 @@ export default function browserAgent() {
 
   // Capture the CLI command for repeatability
   if (process.argv.length > 2) {
-    options.command = process.argv;
+    options.command = process.argv.splice(2);
   }
 
   (async () => {


### PR DESCRIPTION
Added CLI metadata to the output results/config.json generated for a test. This takes process.argv output directly without using .join() in order to not have to worry about escaping of characters for strings passed with the --block argument. 

Resolves issue #81