### PR TITLE
Fix copy button on telescopetest-io

### DIFF
--- a/telescopetest-io/src/pages/index.astro
+++ b/telescopetest-io/src/pages/index.astro
@@ -1324,7 +1324,7 @@ cd telescope</code></pre>
         ↑
     </div>
 
-    <script is;inline>
+    <script is:inline>
         // Generate starfield
         function createStars() {
             const starsContainer = document.getElementById('stars');


### PR DESCRIPTION
Just add a small fix to make the copy buttons actually allow copying: https://docs.astro.build/en/guides/client-side-scripts/#unprocessed-scripts 