### PR TITLE
Add local project initialization steps in README

### DIFF
--- a/telescopetest-io/README.md
+++ b/telescopetest-io/README.md
@@ -4,17 +4,22 @@ This is the website for users to upload and view Telescope ZIP results. This is 
 
 ## Project Setup
 
-This is how to set up the project from scratch.
+This is how to set up the project. These steps are neccessary for local testing.
 
-- First, run `npm install` and make sure you don't run into any problems. If you do, update Node to the most recent version with `nvm install node` or use a different Node version manager.
+- First, make sure your Node version is the most recent and your current directory is `telescopetest-io/`.
+- Run `npm install` and make sure you don't run into any problems. If you do, update Node to the most recent version with `nvm install node` or a different Node version manager.
+- Next, to create a local D1 dev database, run `npx wrangler d1 execute telescope-db-development --local --env development --file=./db/schema.sql`. This will create a local D1 dev database called `telescope-db-development` with the `tests` table as described in `./db/schema.sql`.
+- Next, to create a local R2 Bucket, run `npx wrangler r2 bucket create results-bucket-development`. This step may prompt you to log in with wrangler.
+
+For type safety, Worker and binding types are defined in `worker-configuration.d.ts`. Any changes to the `wrangler.jsonc` require regenerating this file, which you can do by running the command `npm run cf-typegen`.
 
 ## Running Locally
 
-To run this project locally, make sure your Node version is the most recent and change current directory to `telescopetest-io/`. You'll need to then run `npm install` and `npm run preview`.
+Make sure you've followed all steps in Project Setup. Then, you can run `npm run build` and then `npm run dev` to view the site with Astro's hot reload (instantly reflect changes) using the adapter for Cloudflare. Alternatively, you can run `npm run preview` to see Astro with Workers together in one step, but there's no hot reload.
 
 ## Testing in Staging
 
-Staging allows you to test changes in a remote environment that isn't production. To deploy to staging, run `npm run deploy:staging`. This command will only work if you have permission to deploy to telesceoptest-io's Worker.
+Staging allows you to test changes in a remote environment that isn't production. To deploy to staging, run `npm run deploy:staging`. This command will only work if you have permission to deploy to telesceoptest-io's remote Worker.
 
 ## Deployment to Production
 
@@ -24,6 +29,6 @@ Changes to the production website should only be deployed on Cloudflare workers 
 2. Installs Node.js 20
 3. `npm ci` in `telescopetest-io/`
 4. `npm run build` (generates `dist/`)
-5. `npx wrangler deploy` (uploads `dist/` to Cloudflare)
+5. `npx wrangler deploy --env production` (uploads `dist/` to Cloudflare)
 
 Once successful, the deployed site can be found on [telescopetest.io](telescopetest.io).

--- a/telescopetest-io/astro.config.mjs
+++ b/telescopetest-io/astro.config.mjs
@@ -7,8 +7,10 @@ import cloudflare from '@astrojs/cloudflare';
 export default defineConfig({
   output: 'server',
   adapter: cloudflare({
-    platformProxy: {
+    platformProxy: { // only used for `astro dev`: https://docs.astro.build/en/guides/integrations-guide/cloudflare/#platformproxy
       enabled: true,
+      configPath: './wrangler.jsonc',
+      environment: 'development',
     },
 
     imageService: 'cloudflare',

--- a/telescopetest-io/package.json
+++ b/telescopetest-io/package.json
@@ -19,8 +19,5 @@
   "devDependencies": {
     "@types/node": "^25.0.10",
     "wrangler": "^4.61.0"
-  },
-  "engines": {
-    "node": ">18.17.1"
   }
 }


### PR DESCRIPTION
- Wrote and tested Project Setup instructions in README.md for local testing. 
- Changed astro.config.mjs (used with `astro dev`) to work with named "development" env 
- Removed unnecessary Node version requirement in package.json (version already required by wrangler) 
- Tested locally and on staging env 

Resolves #114 