### PR TITLE
Limit deployment of telescopetest.io only to main repo

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,4 +1,7 @@
 name: Deploy telescopetest.io production site (no-op on forks)
+permissions:
+  contents: read
+
 on:
   push:
     branches:


### PR DESCRIPTION
Made the workflow a no-op on forks (only jobs can be limited by a condition, there is no way to limit the whole workflow).

Closes #122 