### PR TITLE
Telescopetest-io: initial opencode setup

### DIFF
--- a/telescopetest-io/.opencode/agents/db.md
+++ b/telescopetest-io/.opencode/agents/db.md
@@ -41,6 +41,6 @@ GOTCHAS:
 - datasource db has no url field — intentional, connection injected via PrismaD1 adapter at runtime
 - DATABASE_URL in .env is only for Prisma Studio and prisma migrate diff — never used at runtime
 - Dates (test_date, created_at) are Int (Unix seconds), not DateTime — no Prisma coercion, all manual conversion
-- updated_at only sets on INSERT via dbgenerated("unixepoch()"), never updates on subsequent writes
+- created_at only sets on INSERT via dbgenerated("unixepoch()"), never updates on subsequent writes
 - source column exists in DB but is not in any select or the Tests type — if adding it, update both Tests type in TestConfig.ts and every select in test-repository.ts
 - Migration stub must be created with wrangler first (npx wrangler d1 migrations create ...), then filled with prisma migrate diff — cannot use prisma migrate directly with D1

--- a/telescopetest-io/.opencode/agents/review.md
+++ b/telescopetest-io/.opencode/agents/review.md
@@ -19,7 +19,6 @@ CHECK FOR:
 - type for read models, interface for props
 - Explicit Prisma select
 - Null/undefined handling for D1 fields
-- R2: .head() before .get()
 - Zod validation on API inputs
 - API responses: { success, error? } with proper status
 - No user input in R2 keys without sanitization

--- a/telescopetest-io/.opencode/agents/telescopetest-io.md
+++ b/telescopetest-io/.opencode/agents/telescopetest-io.md
@@ -57,12 +57,6 @@ CODE CONVENTIONS:
 - Repository functions in test-repository.ts with JSDoc
 - API responses: `{ success, error?, ... }` with proper HTTP status
 
-CSS CONVENTIONS:
-
-- Scoped <style> per file, no Tailwind
-- rem with `/* px */` comment on EVERY value
-- CSS vars only: --panel, --border, --text, --muted, --brand
-
 USER PREFERENCES:
 
 - Consistent layout regardless of missing data (use muted placeholders)

--- a/telescopetest-io/.opencode/agents/ui.md
+++ b/telescopetest-io/.opencode/agents/ui.md
@@ -31,14 +31,17 @@ USER PREFERENCES:
 - Less bold (500-600 weight preferred)
 - No rounded corners on screenshots
 - Horizontal rows, no wrapping
+- Do not use layout shifting to indicate selection/hover
 
 CSS RULES:
 
 - Scoped <style> per file
-- rem with /_ px _/ comment on EVERY value
+- rem with /_ px _/ comment on values that should have rem over px
 - CSS vars only: --panel, --border, --text, --muted, --brand
 - No Tailwind, no hardcoded colors
+- Needs to support light and dark mode using color-scheme variable (Layout.astro)
 - CSS nesting OK
+- Global styles (like h1, h2, etc.) defined in Layout.astro
 
 STACK:
 


### PR DESCRIPTION
Relates to #151 

*Edit - more info on how/why these files: 
- These files were generated initially with Opencode, but I then used them for some other coding and PR work in telescopetest-io and got Opencode to cut down on filler by basically telling it to not worry about being 'human-readable' and just focus on what is useful for it. 
    - Mainly wanted pointers about how to answer, to always be concise, to always use the internet (documentation) and re-read files before inferencing off of them, what I like for code style, code perferences, user preferences, specific env and configurations in the project, and any 'gatchas' (Opencode titled the section 'gatchas') that needed a bit more digging to find
    - Through trial and error I added some CLI commands that it could/couldn't run
    - Asked it to remove anything that was just code or structure regurgitated -> this is also good because now it's less git branch dependent -> when asking it to cut down, I found it useful to set limits (like 'give me one sentence' or 'give me bullet points each 10 words max')
  
In the future, I think adding more subagents rather than adding to the individual MD files is a good idea. Like a telescope.md file for knowing about the `telescope` CLI tool and the structure of tests in `/results` it outputs would probably be useful. 

I did read this recommended article and get a lot from it: https://addyosmani.com/blog/agents-md/

