### PR TITLE
Telescopetest-io: change test_id generation

### DIFF
--- a/telescopetest-io/src/lib/classes/TestConfig.ts
+++ b/telescopetest-io/src/lib/classes/TestConfig.ts
@@ -11,15 +11,6 @@ export enum TestSource {
   UNKNOWN = 'unknown',
 }
 
-// Config.json structure from Telescope test archives
-export interface ConfigJson {
-  url: string;
-  date: string;
-  options: {
-    browser: string;
-  };
-}
-
 // Return type from D1
 export type Tests = {
   test_id: string;

--- a/telescopetest-io/src/pages/api/upload.ts
+++ b/telescopetest-io/src/pages/api/upload.ts
@@ -1,6 +1,6 @@
 import type { APIContext, APIRoute } from 'astro';
 import type { Unzipped } from 'fflate';
-import type { ConfigJson, TestConfig } from '@/lib/classes/TestConfig';
+import type { TestConfig } from '@/lib/classes/TestConfig';
 
 import { unzipSync } from 'fflate';
 import { z } from 'zod';
@@ -140,9 +140,28 @@ export const POST: APIRoute = async (context: APIContext) => {
         { status: 400, headers: { 'Content-Type': 'application/json' } },
       );
     }
+    const configSchema = z.object({
+      url: z.string(),
+      date: z.string(),
+      options: z.object({
+        browser: z.string(),
+      }),
+    });
+    type ConfigJson = z.infer<typeof configSchema>;
     let config: ConfigJson;
     try {
-      config = JSON.parse(configText);
+      const parsed = JSON.parse(configText);
+      const configResult = configSchema.safeParse(parsed);
+      if (!configResult.success) {
+        return new Response(
+          JSON.stringify({
+            success: false,
+            error: `Invalid config.json: ${configResult.error.issues.map(i => i.message).join(', ')}`,
+          }),
+          { status: 400, headers: { 'Content-Type': 'application/json' } },
+        );
+      }
+      config = configResult.data;
     } catch (error) {
       return new Response(
         JSON.stringify({


### PR DESCRIPTION
- Moved the function generateTestId() into upload.ts, now uses config.json "date" rather than date of upload for consistency across telescope agent output and telescopetest-io display
- Use zod for validating the config.json file 
- Tested on staging 

Resolves #124 (talked about the UUID being enough for uniqueness)

QUESTION: For changing the production data that already has `test_id`s, should we just run a script to update them? 