### PR TITLE
Telescopetest-io: update README.md prisma setup section

### DIFF
--- a/telescopetest-io/README.md
+++ b/telescopetest-io/README.md
@@ -18,7 +18,10 @@ Once you've finished the steps above, run these to set up Prisma, the ORM we're 
 
 1. Make sure you have the local `telescope-db-development` table (step 3 above).
 2. Copy the relative path (without telescopetest-io/) of this local `.sqlite` file in the folder `.wrangler/state/v3/d1/miniflare... ` and put this into a new `.env` file at the root of the `telescopetest-io` project as `DATABASE_URL="file:{{relative_path}}`.
+   - **Note for Windows users:** Use forward slashes `/` in the DATABASE_URL path (e.g., `file:./prisma/dev.db`), not backslashes.
+
 3. Run `npm run generate` to generate a Prisma Client.
+4. Run `npm run migrate:local` to apply all existing migrations to your local database.
 
 You should now be able to run `npm run studio` to view local D1 data in Prisma Studio, as well as create migrations.
 
@@ -42,8 +45,8 @@ npx prisma migrate diff \
 
 This should fill your created file with the raw SQLite for your changes.
 
-4. Run `npx wrangler d1 migrations apply telescope-db-development --local --env development`
-5. Regenerate a Prisma Client that reflects your new changes in `schema.prisma` with `npm run generate`.
+4. Run `npm run generate` to regenerate a Prisma Client that reflects your new changes in `schema.prisma`.
+5. Run `npm run migrate:local` to apply this new migration to your local database.
 
 ## Running Locally
 

--- a/telescopetest-io/package.json
+++ b/telescopetest-io/package.json
@@ -10,6 +10,7 @@
     "deploy": "astro build && wrangler deploy --env production",
     "deploy:staging": "astro build && wrangler deploy --env staging",
     "migrate:staging": "npx wrangler d1 migrations apply telescope-db-staging --remote --env staging",
+    "migrate:local": "npx wrangler d1 migrations apply telescope-db-development --local --env development",
     "generate": "prisma generate",
     "studio": "prisma studio"
   },


### PR DESCRIPTION
- Moved the long local migration command into package.json. 
- Made the README instructions for setting up local testing more clear. 
Resolves #167 