### PR TITLE
Dedicated URLs for result tabs

### DIFF
--- a/telescopetest-io/src/components/Tabs.astro
+++ b/telescopetest-io/src/components/Tabs.astro
@@ -1,84 +1,71 @@
+---
+export interface Props {
+  testId: string;
+  activeTab: string;
+}
+
+const { testId, activeTab } = Astro.props;
+
+const tabs = [
+  { id: 'summary', label: 'Summary', href: `/results/${testId}` },
+  { id: 'metrics', label: 'All Metrics', href: `/results/${testId}/metrics` },
+  { id: 'waterfall', label: 'Waterfall', href: `/results/${testId}/waterfall` },
+  { id: 'resources', label: 'Resources', href: `/results/${testId}/resources` },
+  { id: 'console', label: 'Console', href: `/results/${testId}/console` },
+];
+---
+
 <div class="tabs-container">
-  <div class="tabs-header">
-    <button class="tab-btn active" data-tab="summary">Summary</button>
-    <button class="tab-btn" data-tab="all-metrics">All Metrics</button>
-    <button class="tab-btn" data-tab="waterfall">Waterfall</button>
-    <button class="tab-btn" data-tab="resources">Resources</button>
-    <button class="tab-btn" data-tab="console">Console</button>
-  </div>
+  <nav class="tabs-header" aria-label="Result tabs">
+    {
+      tabs.map((tab) => (
+        <a
+          class={`tab-link${tab.id === activeTab ? ' active' : ''}`}
+          href={tab.href}
+          aria-current={tab.id === activeTab ? 'page' : undefined}
+        >
+          {tab.label}
+        </a>
+      ))
+    }
+  </nav>
   <div class="tabs-content">
-    <div class="tab-pane active" data-pane="summary">
-      <slot name="summary" />
-    </div>
-    <div class="tab-pane" data-pane="all-metrics">
-      <slot name="all-metrics" />
-    </div>
-    <div class="tab-pane" data-pane="waterfall">
-      <slot name="waterfall" />
-    </div>
-    <div class="tab-pane" data-pane="resources">
-      <slot name="resources" />
-    </div>
-    <div class="tab-pane" data-pane="console">
-      <slot name="console" />
-    </div>
+    <slot />
   </div>
-
-  <style>
-    .tabs-container {
-      display: flex;
-      flex-direction: column;
-    }
-
-    .tabs-header {
-      display: flex;
-      gap: 0.5rem;
-      border-bottom: 1px solid var(--border);
-      margin-bottom: 1.5rem;
-    }
-
-    .tab-btn {
-      background: none;
-      border: none;
-      border-bottom: 2px solid transparent;
-      padding: 0.75rem 1rem;
-      font-size: 0.9375rem;
-      font-weight: 500;
-      color: var(--muted);
-      cursor: pointer;
-      transition: all 0.2s;
-    }
-
-    .tab-btn:hover {
-      color: var(--text);
-    }
-
-    .tab-btn.active {
-      color: var(--brand);
-      border-bottom-color: var(--brand);
-    }
-
-    .tab-pane {
-      display: none;
-    }
-
-    .tab-pane.active {
-      display: block;
-    }
-  </style>
-
-  <script>
-    const buttons = document.querySelectorAll<HTMLButtonElement>('.tab-btn');
-    const panes = document.querySelectorAll<HTMLElement>('.tab-pane');
-
-    buttons.forEach(btn => {
-      btn.addEventListener('click', () => {
-        const tab = btn.dataset.tab;
-        buttons.forEach(b => b.classList.remove('active'));
-        panes.forEach(p => p.classList.remove('active'));
-        btn.classList.add('active');
-        document.querySelector(`[data-pane="${tab}"]`)?.classList.add('active');
-      });
-    });
-  </script>
 </div>
+
+<style>
+  .tabs-container {
+    display: flex;
+    flex-direction: column;
+  }
+
+  .tabs-header {
+    display: flex;
+    gap: 0.5rem;
+    border-bottom: 1px solid var(--border);
+    margin-bottom: 1.5rem;
+  }
+
+  .tab-link {
+    background: none;
+    border: none;
+    border-bottom: 2px solid transparent;
+    padding: 0.75rem 1rem;
+    font-size: 0.9375rem;
+    font-weight: 500;
+    color: var(--muted);
+    cursor: pointer;
+    transition: all 0.2s;
+    text-decoration: none;
+  }
+
+  .tab-link:hover {
+    color: var(--text);
+  }
+
+  .tab-link.active {
+    color: var(--brand);
+    border-bottom-color: var(--brand);
+  }
+</style>

--- a/telescopetest-io/src/layouts/ResultLayout.astro
+++ b/telescopetest-io/src/layouts/ResultLayout.astro
@@ -1,0 +1,292 @@
+---
+import Page from './Page.astro';
+import ScreenshotDisplay from '@/components/ScreenshotDisplay.astro';
+import TestInfoPanel from '@/components/TestInfoPanel.astro';
+import Tabs from '@/components/Tabs.astro';
+
+export interface Props {
+  testId: string;
+  title: string;
+  url: string;
+  name: string | null;
+  description: string | null;
+  browser: string;
+  browserVersion: string | null;
+  formattedDate: string;
+  screenshotUrl: string | null;
+  isUnknown: boolean;
+  isUnsafe: boolean;
+  activeTab: string;
+}
+
+const {
+  testId,
+  title,
+  url,
+  name,
+  description,
+  browser,
+  browserVersion,
+  formattedDate,
+  screenshotUrl,
+  isUnknown,
+  isUnsafe,
+  activeTab,
+} = Astro.props;
+---
+
+<Page title={title}>
+  <div class="detail-header">
+    <a href="/results" class="back-link">← Back to all results</a>
+  </div>
+  <div class="sections">
+    {
+      isUnsafe && (
+        <div class="banner banner-unsafe">
+          <strong>This result cannot be displayed.</strong>
+          <p>
+            The content was rated unsafe by our AI content filter. To view
+            unsafe results, run telescopetest.io locally and upload there.
+          </p>
+        </div>
+      )
+    }
+
+    {
+      isUnknown && (
+        <>
+          <div class="banner banner-pending" id="rating-pending">
+            <strong>Rating in progress...</strong>
+            <p>
+              AI content rating is running. This page will update automatically.
+            </p>
+          </div>
+          <div
+            class="banner banner-pending"
+            id="rating-timeout"
+            style="display: none;"
+          >
+            <strong>Rating timed out.</strong>
+            <p>
+              Content rating could not be completed. Please refresh to try again.
+            </p>
+          </div>
+        </>
+      )
+    }
+
+    {
+      !isUnsafe && !isUnknown && (
+        <>
+          <div class="title-section">
+            {name ? <h1>{name}</h1> : <h1>{testId}</h1>}
+            {description && (
+              <div class="description-details">
+                <p class="description-text">{description}</p>
+                <button class="description-toggle" aria-expanded="false">
+                  more
+                </button>
+              </div>
+            )}
+          </div>
+
+          <section class="overview-section">
+            <TestInfoPanel
+              testId={testId}
+              url={url}
+              browser={browser}
+              browserVersion={browserVersion}
+              formattedDate={formattedDate}
+            />
+
+            <ScreenshotDisplay
+              screenshotUrl={screenshotUrl}
+              alt={`Screenshot of ${url}`}
+            />
+          </section>
+
+          <Tabs testId={testId} activeTab={activeTab}>
+            <slot />
+          </Tabs>
+        </>
+      )
+    }
+  </div>
+</Page>
+
+<style>
+  .banner {
+    margin-top: 1.5rem;
+    padding: 1.25rem 1.5rem;
+    border-radius: 0.75rem;
+    border: 1px solid;
+  }
+
+  .banner strong {
+    display: block;
+    margin-bottom: 0.5rem;
+    font-size: 1rem;
+  }
+
+  .banner p {
+    margin: 0;
+    font-size: 0.875rem;
+    line-height: 1.5;
+    color: var(--muted);
+  }
+
+  .banner-unsafe {
+    background: rgba(239, 68, 68, 0.08);
+    border-color: rgba(239, 68, 68, 0.4);
+  }
+
+  .banner-unsafe strong {
+    color: rgba(239, 68, 68, 0.9);
+  }
+
+  .banner-pending {
+    background: rgba(251, 191, 36, 0.08);
+    border-color: rgba(251, 191, 36, 0.4);
+  }
+
+  .banner-pending strong {
+    color: rgba(251, 191, 36, 0.9);
+  }
+
+  .detail-header {
+    margin-bottom: 1.5rem;
+  }
+
+  .back-link {
+    display: inline-block;
+    color: var(--muted);
+    text-decoration: none;
+    font-size: 0.875rem;
+    transition: color 0.2s ease;
+  }
+
+  .back-link:hover {
+    color: var(--brand);
+  }
+
+  .sections {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+  }
+
+  .title-section h1 {
+    margin: 0 0 0.25rem 0;
+    font-size: 2rem;
+    font-weight: 700;
+    overflow: hidden;
+    display: -webkit-box;
+    -webkit-box-orient: vertical;
+    -webkit-line-clamp: 2;
+  }
+
+  .description-text {
+    margin: 0 0 0.25rem 0;
+    font-size: 1rem;
+    font-weight: 400;
+    overflow: hidden;
+    display: -webkit-box;
+    -webkit-box-orient: vertical;
+    -webkit-line-clamp: 1;
+    word-break: break-all;
+  }
+
+  .description-toggle {
+    background: none;
+    border: none;
+    padding: 0;
+    font-size: 0.8125rem;
+    color: var(--brand);
+    cursor: pointer;
+  }
+
+  .overview-section {
+    display: flex;
+    gap: 2rem;
+    align-items: stretch;
+  }
+
+  .overview-section :global(.info-panel) {
+    flex: 2;
+    min-width: 0;
+  }
+
+  .overview-section :global(.screenshot-wrap),
+  .overview-section :global(.screenshot-empty) {
+    flex: 1;
+    min-width: 0;
+  }
+
+  .overview-section :global(.screenshot-wrap) {
+    display: flex;
+    align-items: stretch;
+  }
+
+  .overview-section :global(.screenshot-wrap img) {
+    width: 100%;
+    height: 100%;
+    object-fit: contain;
+  }
+
+  @media (max-width: 64rem) {
+    .overview-section {
+      flex-direction: column;
+    }
+  }
+</style>
+
+<script data-test-id={testId}>
+  // AI content rating polling
+  if (document.getElementById('rating-pending')) {
+    const INTERVAL_MS = 2000;
+    const TIMEOUT_MS = 30_000;
+    const start = Date.now();
+    // Extract testId from the data attribute on the script tag
+    const scriptEl = document.querySelector('script[data-test-id]');
+    const testId = scriptEl?.getAttribute('data-test-id');
+    const pendingBanner = document.getElementById('rating-pending');
+    const timeoutBanner = document.getElementById('rating-timeout');
+    async function poll() {
+      if (Date.now() - start >= TIMEOUT_MS) {
+        if (pendingBanner) pendingBanner.style.display = 'none';
+        if (timeoutBanner) timeoutBanner.style.display = '';
+        return;
+      }
+      try {
+        const res = await fetch(`/api/tests/${testId}/rating`);
+        const data = await res.json();
+        if (data.rating === 'safe' || data.rating === 'unsafe') {
+          window.location.reload();
+          return;
+        }
+        setTimeout(poll, INTERVAL_MS);
+      } catch {
+        setTimeout(poll, INTERVAL_MS);
+      }
+    }
+    setTimeout(poll, INTERVAL_MS);
+  }
+  // Description toggle
+  const toggle = document.querySelector('.description-toggle');
+  const text = document.querySelector('.description-text');
+  if (toggle && text) {
+    toggle.addEventListener('click', () => {
+      const expanded = toggle.getAttribute('aria-expanded') === 'true';
+      const el = /** @type {HTMLElement} */ (text);
+      if (expanded) {
+        el.style.overflow = '';
+        el.style.webkitLineClamp = '';
+      } else {
+        el.style.overflow = 'visible';
+        el.style.webkitLineClamp = 'unset';
+      }
+      toggle.setAttribute('aria-expanded', String(!expanded));
+      toggle.textContent = expanded ? 'more' : 'less';
+    });
+  }
+</script>

--- a/telescopetest-io/src/lib/cache/r2Cache.ts
+++ b/telescopetest-io/src/lib/cache/r2Cache.ts
@@ -1,0 +1,176 @@
+/**
+ * In-memory LRU cache for parsed R2 objects.
+ *
+ * Test results are immutable — once uploaded they never change — so caching
+ * parsed JSON from R2 across requests within the same Worker isolate is safe.
+ *
+ * This avoids re-fetching and re-parsing heavy files (e.g. HAR files that can
+ * be several hundred KB) when users navigate between result tabs.
+ *
+ * The cache is bounded by both entry count and total estimated byte size to
+ * prevent unbounded memory growth.
+ */
+
+const MAX_ENTRIES = 200;
+const MAX_BYTES = 50 * 1024 * 1024; // 50 MB soft limit
+
+interface CacheEntry {
+  value: unknown;
+  size: number;
+  lastAccess: number;
+}
+
+const cache = new Map<string, CacheEntry>();
+let totalBytes = 0;
+
+function estimateSize(value: unknown): number {
+  // Fast rough estimate — JSON.stringify length × 2 for UTF-16
+  // Only computed once at insertion time.
+  try {
+    return JSON.stringify(value).length * 2;
+  } catch {
+    return 1024; // fallback for non-serialisable values
+  }
+}
+
+function evict(): void {
+  // Evict least-recently-accessed entries until we're under limits.
+  while (cache.size > MAX_ENTRIES || totalBytes > MAX_BYTES) {
+    let oldestKey: string | null = null;
+    let oldestTime = Infinity;
+    for (const [key, entry] of cache) {
+      if (entry.lastAccess < oldestTime) {
+        oldestTime = entry.lastAccess;
+        oldestKey = key;
+      }
+    }
+    if (oldestKey) {
+      const entry = cache.get(oldestKey)!;
+      totalBytes -= entry.size;
+      cache.delete(oldestKey);
+    } else {
+      break;
+    }
+  }
+}
+
+/**
+ * Get a parsed JSON value from the cache.
+ * Returns `undefined` on cache miss.
+ */
+export function getCached<T>(key: string): T | undefined {
+  const entry = cache.get(key);
+  if (entry) {
+    entry.lastAccess = Date.now();
+    return entry.value as T;
+  }
+  return undefined;
+}
+
+/**
+ * Store a parsed JSON value in the cache.
+ */
+export function setCached(key: string, value: unknown): void {
+  // If already cached, remove old entry's size contribution first
+  const existing = cache.get(key);
+  if (existing) {
+    totalBytes -= existing.size;
+  }
+
+  const size = estimateSize(value);
+  cache.set(key, { value, size, lastAccess: Date.now() });
+  totalBytes += size;
+  evict();
+}
+
+/**
+ * Check whether an R2 key is known to exist (from a prior .get() or .head()).
+ * Returns `undefined` if we don't know.
+ */
+export function getExistsCached(key: string): boolean | undefined {
+  const entry = cache.get(`__exists__${key}`);
+  if (entry) {
+    entry.lastAccess = Date.now();
+    return entry.value as boolean;
+  }
+  return undefined;
+}
+
+/**
+ * Record whether an R2 key exists. Tiny entries (just a boolean).
+ */
+export function setExistsCached(key: string, exists: boolean): void {
+  const cacheKey = `__exists__${key}`;
+  const existing = cache.get(cacheKey);
+  if (existing) {
+    totalBytes -= existing.size;
+  }
+  const size = 64; // boolean + key overhead
+  cache.set(cacheKey, { value: exists, size, lastAccess: Date.now() });
+  totalBytes += size;
+  // No evict needed for tiny entries but keep it safe
+  evict();
+}
+
+/**
+ * Fetch a JSON file from R2, using the cache for deduplication.
+ *
+ * Returns `null` if the object doesn't exist.
+ * Caches both the parsed result and the existence flag.
+ */
+export async function getR2Json<T>(
+  bucket: any,
+  key: string,
+): Promise<T | null> {
+  // Check cache first
+  const cached = getCached<T>(key);
+  if (cached !== undefined) {
+    return cached;
+  }
+
+  // Check if we already know it doesn't exist
+  const exists = getExistsCached(key);
+  if (exists === false) {
+    return null;
+  }
+
+  try {
+    const obj = await bucket.get(key);
+    if (!obj) {
+      setExistsCached(key, false);
+      return null;
+    }
+    setExistsCached(key, true);
+    const parsed = (await obj.json()) as T;
+    setCached(key, parsed);
+    return parsed;
+  } catch (err) {
+    console.error(`Error reading ${key} from R2:`, err);
+    return null;
+  }
+}
+
+/**
+ * Check if an R2 object exists, using the cache.
+ * Uses .head() which is cheaper than .get().
+ */
+export async function r2Exists(bucket: any, key: string): Promise<boolean> {
+  const cached = getExistsCached(key);
+  if (cached !== undefined) {
+    return cached;
+  }
+
+  // If we already have the full object cached, it exists
+  if (getCached(key) !== undefined) {
+    return true;
+  }
+
+  try {
+    const obj = await bucket.head(key);
+    const exists = obj !== null;
+    setExistsCached(key, exists);
+    return exists;
+  } catch {
+    return false;
+  }
+}

--- a/telescopetest-io/src/lib/loaders/testResult.ts
+++ b/telescopetest-io/src/lib/loaders/testResult.ts
@@ -1,0 +1,92 @@
+/**
+ * Shared data loader for test result pages.
+ *
+ * Every tab page (summary, metrics, waterfall, resources, console) needs
+ * the core test record, AI-rating flags, screenshot URL, HAR browser info,
+ * and a formatted date string. This module fetches all of that once and
+ * returns it in a single object so each page doesn't duplicate the logic.
+ */
+import type { AstroGlobal } from 'astro';
+import { getPrismaClient } from '@/lib/prisma/client';
+import { getTestById } from '@/lib/repositories/testRepository';
+import { ContentRating } from '@/lib/types/tests';
+import { getR2Json, r2Exists } from '@/lib/cache/r2Cache';
+
+export interface TestResultBase {
+  testId: string;
+  test: NonNullable<Awaited<ReturnType<typeof getTestById>>>;
+  isUnknown: boolean;
+  isUnsafe: boolean;
+  screenshotUrl: string | null;
+  harBrowser: { name: string; version: string } | null;
+  hasHar: boolean;
+  formattedDate: string;
+}
+
+/**
+ * Load the common test-result data needed by every tab.
+ *
+ * Returns `null` when testId is missing or the test doesn't exist —
+ * callers should `Astro.redirect('/results')` in that case.
+ */
+export async function loadTestResult(
+  Astro: AstroGlobal,
+): Promise<TestResultBase | null> {
+  const testId = Astro.params.testId as string | undefined;
+  if (!testId) return null;
+
+  const env = (Astro.locals as any).runtime.env;
+  const prisma = getPrismaClient(Astro);
+  const test = await getTestById(prisma, testId);
+  if (!test) return null;
+
+  const aiEnabled = env.ENABLE_AI_RATING === 'true';
+  const isUnknown =
+    aiEnabled &&
+    (test.content_rating === ContentRating.UNKNOWN ||
+      test.content_rating === ContentRating.IN_PROGRESS);
+  const isUnsafe = aiEnabled && test.content_rating === ContentRating.UNSAFE;
+
+  // Screenshot — just check existence, don't download the image
+  const screenshotKey = `${testId}/screenshot.png`;
+  const hasScreenshot = await r2Exists(env.RESULTS_BUCKET, screenshotKey);
+  const screenshotUrl = hasScreenshot
+    ? `/api/tests/${testId}/screenshot.png`
+    : null;
+
+  // HAR browser info + existence check.
+  // The full HAR is cached so subsequent reads (e.g. waterfall tab client
+  // fetching the same file via the API route) can skip re-parsing.
+  let harBrowser: { name: string; version: string } | null = null;
+  let hasHar = false;
+  const harKey = `${testId}/pageload.har`;
+  const har = await getR2Json<{
+    log: { browser: { name: string; version: string } };
+  }>(env.RESULTS_BUCKET, harKey);
+  if (har) {
+    hasHar = true;
+    harBrowser = har?.log?.browser ?? null;
+  }
+
+  // Formatted date
+  const date = new Date(test.test_date * 1000);
+  const formattedDate = date.toLocaleString('en-US', {
+    month: 'short',
+    day: 'numeric',
+    year: 'numeric',
+    hour: '2-digit',
+    minute: '2-digit',
+    timeZoneName: 'short',
+  });
+
+  return {
+    testId,
+    test,
+    isUnknown,
+    isUnsafe,
+    screenshotUrl,
+    harBrowser,
+    hasHar,
+    formattedDate,
+  };
+}

--- a/telescopetest-io/src/pages/results/[testId].astro
+++ b/telescopetest-io/src/pages/results/[testId].astro
@@ -1,21 +1,9 @@
 ---
-import Page from '@/layouts/Page.astro';
+import ResultLayout from '@/layouts/ResultLayout.astro';
 import MetricCard from '@/components/MetricCard.astro';
-import ScreenshotDisplay from '@/components/ScreenshotDisplay.astro';
-import TestInfoPanel from '@/components/TestInfoPanel.astro';
-import Tabs from '@/components/Tabs.astro';
-import AllMetrics from '@/components/AllMetrics.astro';
-import Waterfall from '@/components/Waterfall.astro';
-import Resources from '@/components/Resources.astro';
-import Console from '@/components/Console.astro';
-
-import { getPrismaClient } from '@/lib/prisma/client';
-import { getTestById } from '@/lib/repositories/testRepository';
-import { ContentRating } from '@/lib/types/tests';
-
+import { loadTestResult } from '@/lib/loaders/testResult';
+import { getR2Json } from '@/lib/cache/r2Cache';
 import type { MetricsJson } from '@/lib/types/metrics';
-import type { ResourceTiming } from '@/lib/types/resources';
-import type { ConsoleMessage } from '@/lib/types/console';
 import { getLcp, getCls } from '@/lib/utils/cwv';
 import {
   getFcp,
@@ -27,500 +15,125 @@ import { formatMs, formatKb } from '@/lib/utils/formatters';
 
 export const prerender = false;
 
-const { testId } = Astro.params;
-if (!testId) {
+const result = await loadTestResult(Astro);
+if (!result) {
   return Astro.redirect('/results');
 }
 
-const env = Astro.locals.runtime.env;
-const aiEnabled = env.ENABLE_AI_RATING === 'true';
+const { testId, test, isUnknown, isUnsafe, screenshotUrl, harBrowser, formattedDate } = result;
 
-const prisma = getPrismaClient(Astro);
-const test = await getTestById(prisma, testId);
-if (!test) {
-  return Astro.redirect('/results');
-}
+// --- Metrics (only needed for summary tab) ---
+const env = (Astro.locals as any).runtime.env;
+const metrics = await getR2Json<MetricsJson>(env.RESULTS_BUCKET, `${testId}/metrics.json`);
 
-// When AI rating is disabled, treat everything as safe
-const isUnknown =
-  aiEnabled &&
-  (test.content_rating === ContentRating.UNKNOWN ||
-    test.content_rating === ContentRating.IN_PROGRESS);
-const isUnsafe = aiEnabled && test.content_rating === ContentRating.UNSAFE;
-
-// --- Screenshot ---
-const screenshotKey = `${testId}/screenshot.png`;
-const screenshotObj = await env.RESULTS_BUCKET.head(screenshotKey);
-const screenshotUrl = screenshotObj
-  ? `/api/tests/${testId}/screenshot.png`
-  : null;
-
-// --- HAR (browser version + existence check for Waterfall) ---
-let harBrowser: { name: string; version: string } | null = null;
-let hasHar = false;
-try {
-  const harObj = await env.RESULTS_BUCKET.get(`${testId}/pageload.har`);
-  if (harObj) {
-    hasHar = true;
-    const har = await harObj.json<{
-      log: { browser: { name: string; version: string } };
-    }>();
-    harBrowser = har?.log?.browser ?? null;
-  }
-} catch (err) {
-  console.error('Error reading HAR browser info:', err);
-  // HAR unavailable — render without browser version
-}
-
-// --- Metrics ---
-let metrics: MetricsJson | null = null;
-try {
-  const metricsObj = await env.RESULTS_BUCKET.get(`${testId}/metrics.json`);
-  if (metricsObj) {
-    metrics = await metricsObj.json<MetricsJson>();
-  }
-} catch (err) {
-  console.error('Error reading metrics.json:', err);
-  // metrics unavailable — render without them
-}
-
-// --- Resources ---
-let resources: ResourceTiming[] = [];
-try {
-  const resourcesObj = await env.RESULTS_BUCKET.get(`${testId}/resources.json`);
-  if (resourcesObj) {
-    resources = await resourcesObj.json<ResourceTiming[]>();
-  }
-} catch (err) {
-  console.error('Error reading resources.json:', err);
-  // resources unavailable — render without them
-}
-
-// --- Console Messages ---
-let consoleMessages: ConsoleMessage[] = [];
-try {
-  const consoleObj = await env.RESULTS_BUCKET.get(`${testId}/console.json`);
-  if (consoleObj) {
-    consoleMessages = await consoleObj.json<ConsoleMessage[]>();
-  }
-} catch (err) {
-  console.error('Error reading console.json:', err);
-  // console messages unavailable — render without them
-}
-
-// Extract metric values
 const lcp = getLcp(metrics);
 const cls = getCls(metrics);
 const fcp = getFcp(metrics);
 const ttfb = getTtfb(metrics);
 const transferBytes = extractTransferSize(metrics);
 const durationMs = extractDuration(metrics);
-
-// Formatted date
-const date = new Date(test.test_date * 1000);
-const formattedDate = date.toLocaleString('en-US', {
-  month: 'short',
-  day: 'numeric',
-  year: 'numeric',
-  hour: '2-digit',
-  minute: '2-digit',
-  timeZoneName: 'short',
-});
 ---
 
-<Page title={test.name ?? `Test ${testId}`}>
-  <div class="detail-header">
-    <a href="/results" class="back-link">← Back to all results</a>
-  </div>
-  <div class="sections">
-    {
-      isUnsafe && (
-        <div class="banner banner-unsafe">
-          <strong>This result cannot be displayed.</strong>
-          <p>
-            The content was rated unsafe by our AI content filter. To view
-            unsafe results, run telescopetest.io locally and upload there.
-          </p>
-        </div>
-      )
-    }
-
-    {
-      isUnknown && (
-        <>
-          <div class="banner banner-pending" id="rating-pending">
-            <strong>Rating in progress...</strong>
-            <p>
-              AI content rating is running. This page will update automatically.
-            </p>
-          </div>
-          <div
-            class="banner banner-pending"
-            id="rating-timeout"
-            style="display: none;"
-          >
-            <strong>Rating timed out.</strong>
-            <p>
-              Content rating could not be completed. Please refresh to try again.
-            </p>
-          </div>
-        </>
-      )
-    }
-
-    {
-      !isUnsafe && !isUnknown && (
-        <>
-          <div class="title-section">
-            {test.name ? <h1>{test.name}</h1> : <h1>{test.test_id}</h1>}
-            {test.description && (
-              <div class="description-details">
-                <p class="description-text">{test.description}</p>
-                <button class="description-toggle" aria-expanded="false">
-                  more
-                </button>
-              </div>
-            )}
-          </div>
-
-          <section class="overview-section">
-            <TestInfoPanel
-              testId={testId}
-              url={test.url}
-              browser={test.browser}
-              browserVersion={harBrowser?.version ?? null}
-              formattedDate={formattedDate}
-            />
-
-            <ScreenshotDisplay
-              screenshotUrl={screenshotUrl}
-              alt={`Screenshot of ${test.url}`}
-            />
-          </section>
-
-          <Tabs>
-      <div slot="summary">
-        {
-          metrics ? (
-            <div class="metrics-row">
-              <MetricCard
-                heading="Core Web Vitals"
-                metrics={[
-                  {
-                    label: 'LCP',
-                    value: lcp.formatted,
-                    unit: 'ms',
-                    rating: lcp.rating,
-                  },
-                  { label: 'CLS', value: cls.formatted, rating: cls.rating },
-                ]}
-              />
-              <MetricCard
-                heading="Performance Metrics"
-                metrics={[
-                  {
-                    label: 'FCP',
-                    value: fcp.formatted,
-                    unit: 'ms',
-                    rating: fcp.rating,
-                  },
-                  {
-                    label: 'TTFB',
-                    value: ttfb.formatted,
-                    unit: 'ms',
-                    rating: ttfb.rating,
-                  },
-                  {
-                    label: 'Transfer Size',
-                    value: formatKb(transferBytes),
-                    unit: 'KB',
-                  },
-                  {
-                    label: 'Page Load Time',
-                    value: formatMs(durationMs),
-                    unit: 'ms',
-                  },
-                ]}
-              />
-            </div>
-          ) : (
-            <div class="metrics-unavailable panel">
-              <p>Metrics unavailable for this test.</p>
-            </div>
-          )
-        }
+<ResultLayout
+  testId={testId}
+  title={test.name ?? `Test ${testId}`}
+  url={test.url}
+  name={test.name}
+  description={test.description}
+  browser={test.browser}
+  browserVersion={harBrowser?.version ?? null}
+  formattedDate={formattedDate}
+  screenshotUrl={screenshotUrl}
+  isUnknown={isUnknown}
+  isUnsafe={isUnsafe}
+  activeTab="summary"
+>
+  {
+    metrics ? (
+      <div class="metrics-row">
+        <MetricCard
+          heading="Core Web Vitals"
+          metrics={[
+            {
+              label: 'LCP',
+              value: lcp.formatted,
+              unit: 'ms',
+              rating: lcp.rating,
+            },
+            { label: 'CLS', value: cls.formatted, rating: cls.rating },
+          ]}
+        />
+        <MetricCard
+          heading="Performance Metrics"
+          metrics={[
+            {
+              label: 'FCP',
+              value: fcp.formatted,
+              unit: 'ms',
+              rating: fcp.rating,
+            },
+            {
+              label: 'TTFB',
+              value: ttfb.formatted,
+              unit: 'ms',
+              rating: ttfb.rating,
+            },
+            {
+              label: 'Transfer Size',
+              value: formatKb(transferBytes),
+              unit: 'KB',
+            },
+            {
+              label: 'Page Load Time',
+              value: formatMs(durationMs),
+              unit: 'ms',
+            },
+          ]}
+        />
       </div>
-
-      <div slot="all-metrics">
-        {
-          metrics ? (
-            <AllMetrics metrics={metrics} />
-          ) : (
-            <div class="metrics-unavailable panel">
-              <p>Metrics unavailable for this test.</p>
-            </div>
-          )
-        }
+    ) : (
+      <div class="metrics-unavailable panel">
+        <p>Metrics unavailable for this test.</p>
       </div>
-
-      <div slot="waterfall">
-        <Waterfall testId={testId} hasHar={hasHar} />
-      </div>
-
-      <div slot="resources">
-        {
-          resources.length > 0 || metrics?.navigationTiming ? (
-            <Resources
-              resources={resources}
-              url={test.url}
-              navigationTiming={metrics?.navigationTiming}
-            />
-          ) : (
-            <div class="resources-unavailable">
-              <p>Resources data unavailable for this test.</p>
-            </div>
-          )
-        }
-      </div>
-
-            <div slot="console">
-              <Console messages={consoleMessages} />
-            </div>
-          </Tabs>
-        </>
-      )
-    }
-  </div>
-</Page>
+    )
+  }
+</ResultLayout>
 
 <style>
-  .banner {
-    margin-top: 1.5rem;
-    padding: 1.25rem 1.5rem;
-    border-radius: 0.75rem;
-    border: 1px solid;
-  }
-
-  .banner strong {
-    display: block;
-    margin-bottom: 0.5rem;
-    font-size: 1rem;
-  }
-
-  .banner p {
-    margin: 0;
-    font-size: 0.875rem;
-    line-height: 1.5;
-    color: var(--muted);
-  }
-
-  .banner-unsafe {
-    background: rgba(239, 68, 68, 0.08);
-    border-color: rgba(239, 68, 68, 0.4);
-  }
-
-  .banner-unsafe strong {
-    color: rgba(239, 68, 68, 0.9);
-  }
-
-  .banner-pending {
-    background: rgba(251, 191, 36, 0.08);
-    border-color: rgba(251, 191, 36, 0.4);
-  }
-
-  .banner-pending strong {
-    color: rgba(251, 191, 36, 0.9);
-  }
-
-  .detail-header {
-    margin-bottom: 1.5rem; /* 24px */
-  }
-
-  .back-link {
-    display: inline-block;
-    color: var(--muted);
-    text-decoration: none;
-    font-size: 0.875rem; /* 14px */
-    transition: color 0.2s ease;
-  }
-
-  .back-link:hover {
-    color: var(--brand);
-  }
-
-  .sections {
+  .metrics-row {
     display: flex;
-    flex-direction: column;
-    gap: 1rem;
+    gap: 3rem;
   }
 
   .panel {
     background: var(--panel);
     border: 1px solid var(--border);
-    border-radius: 0.75rem; /* 12px */
-    padding: 1rem 1.25rem; /* 16px 20px */
+    border-radius: 0.75rem;
+    padding: 1rem 1.25rem;
   }
 
-  .title-section h1 {
-    margin: 0 0 0.25rem 0; /* 4px bottom */
-    font-size: 2rem; /* 32px */
-    font-weight: 700;
-    overflow: hidden;
-    display: -webkit-box;
-    -webkit-box-orient: vertical;
-    -webkit-line-clamp: 2;
-  }
-
-  .description-text {
-    margin: 0 0 0.25rem 0;
-    font-size: 1rem;
-    font-weight: 400;
-    overflow: hidden;
-    display: -webkit-box;
-    -webkit-box-orient: vertical;
-    -webkit-line-clamp: 1;
-    word-break: break-all;
-  }
-
-  .description-toggle {
-    background: none;
-    border: none;
-    padding: 0;
-    font-size: 0.8125rem;
-    color: var(--brand);
-    cursor: pointer;
-  }
-
-  /* Info panel + screenshot side by side - full width split */
-  .overview-section {
-    display: flex;
-    gap: 2rem; /* 32px */
-    align-items: stretch;
-  }
-
-  .overview-section :global(.info-panel) {
-    flex: 2;
-    min-width: 0;
-  }
-
-  .overview-section :global(.screenshot-wrap),
-  .overview-section :global(.screenshot-empty) {
-    flex: 1;
-    min-width: 0;
-  }
-
-  .overview-section :global(.screenshot-wrap) {
-    display: flex;
-    align-items: stretch;
-  }
-
-  .overview-section :global(.screenshot-wrap img) {
-    width: 100%;
-    height: 100%;
-    object-fit: contain;
-  }
-
-  /* Metrics row */
-  .metrics-row {
-    display: flex;
-    gap: 3rem; /* 48px */
-  }
-
-  /* Metrics unavailable */
   .metrics-unavailable {
-    padding: 2.5rem; /* 40px */
+    padding: 2.5rem;
     text-align: center;
     color: var(--muted);
-    font-size: 0.875rem; /* 14px */
+    font-size: 0.875rem;
   }
 
   .metrics-unavailable p {
     margin: 0;
   }
 
-  /* Resources unavailable */
-  .resources-unavailable {
-    padding: 2.5rem; /* 40px */
-    text-align: center;
-    color: var(--muted);
-    font-size: 0.875rem; /* 14px */
-  }
-
-  .resources-unavailable p {
-    margin: 0;
-  }
-
-  /* Responsive: stack on smaller screens */
   @media (max-width: 64rem) {
-    /* 1024px */
-    .overview-section {
-      flex-direction: column;
-    }
-
     .metrics-row {
       grid-template-columns: 1fr;
-      gap: 1.5rem; /* 24px */
+      gap: 1.5rem;
     }
   }
 
-  /* Allow metrics to wrap on narrower screens */
   @media (max-width: 48rem) {
-    /* 768px */
     .metrics-row {
       display: flex;
       flex-direction: column;
     }
   }
 </style>
-
-<script>
-  // AI content rating polling
-  if (document.getElementById('rating-pending')) {
-    const INTERVAL_MS = 2000;
-    const TIMEOUT_MS = 30_000;
-    const start = Date.now();
-    const testId = window.location.pathname.split('/').at(-1);
-    const pendingBanner = document.getElementById('rating-pending');
-    const timeoutBanner = document.getElementById('rating-timeout');
-    async function poll() {
-      if (Date.now() - start >= TIMEOUT_MS) {
-        if (pendingBanner) pendingBanner.style.display = 'none';
-        if (timeoutBanner) timeoutBanner.style.display = '';
-        return;
-      }
-      try {
-        const res = await fetch(`/api/tests/${testId}/rating`);
-        const data: { rating: string } = await res.json();
-        if (data.rating === 'safe' || data.rating === 'unsafe') {
-          window.location.reload();
-          return;
-        }
-        setTimeout(poll, INTERVAL_MS);
-      } catch {
-        setTimeout(poll, INTERVAL_MS);
-      }
-    }
-    setTimeout(poll, INTERVAL_MS);
-  }
-  // Description toggle
-  const toggle = document.querySelector(
-    '.description-toggle',
-  ) as HTMLButtonElement | null;
-  const text = document.querySelector(
-    '.description-text',
-  ) as HTMLElement | null;
-  if (toggle && text) {
-    toggle.addEventListener('click', () => {
-      const expanded = toggle.getAttribute('aria-expanded') === 'true';
-      if (expanded) {
-        text.style.overflow = '';
-        text.style.webkitLineClamp = '';
-      } else {
-        text.style.overflow = 'visible';
-        text.style.webkitLineClamp = 'unset';
-      }
-      toggle.setAttribute('aria-expanded', String(!expanded));
-      toggle.textContent = expanded ? 'more' : 'less';
-    });
-  }
-</script>

--- a/telescopetest-io/src/pages/results/[testId]/console.astro
+++ b/telescopetest-io/src/pages/results/[testId]/console.astro
@@ -1,0 +1,37 @@
+---
+import ResultLayout from '@/layouts/ResultLayout.astro';
+import ConsoleView from '@/components/Console.astro';
+import { loadTestResult } from '@/lib/loaders/testResult';
+import { getR2Json } from '@/lib/cache/r2Cache';
+import type { ConsoleMessage } from '@/lib/types/console';
+
+export const prerender = false;
+
+const result = await loadTestResult(Astro);
+if (!result) {
+  return Astro.redirect('/results');
+}
+
+const { testId, test, isUnknown, isUnsafe, screenshotUrl, harBrowser, formattedDate } = result;
+
+// --- Console Messages ---
+const env = (Astro.locals as any).runtime.env;
+const consoleMessages = await getR2Json<ConsoleMessage[]>(env.RESULTS_BUCKET, `${testId}/console.json`) ?? [];
+---
+
+<ResultLayout
+  testId={testId}
+  title={`Console · ${test.name ?? testId}`}
+  url={test.url}
+  name={test.name}
+  description={test.description}
+  browser={test.browser}
+  browserVersion={harBrowser?.version ?? null}
+  formattedDate={formattedDate}
+  screenshotUrl={screenshotUrl}
+  isUnknown={isUnknown}
+  isUnsafe={isUnsafe}
+  activeTab="console"
+>
+  <ConsoleView messages={consoleMessages} />
+</ResultLayout>

--- a/telescopetest-io/src/pages/results/[testId]/metrics.astro
+++ b/telescopetest-io/src/pages/results/[testId]/metrics.astro
@@ -1,0 +1,61 @@
+---
+import ResultLayout from '@/layouts/ResultLayout.astro';
+import AllMetrics from '@/components/AllMetrics.astro';
+import { loadTestResult } from '@/lib/loaders/testResult';
+import { getR2Json } from '@/lib/cache/r2Cache';
+import type { MetricsJson } from '@/lib/types/metrics';
+
+export const prerender = false;
+
+const result = await loadTestResult(Astro);
+if (!result) {
+  return Astro.redirect('/results');
+}
+
+const { testId, test, isUnknown, isUnsafe, screenshotUrl, harBrowser, formattedDate } = result;
+
+// --- Metrics ---
+const env = (Astro.locals as any).runtime.env;
+const metrics = await getR2Json<MetricsJson>(env.RESULTS_BUCKET, `${testId}/metrics.json`);
+---
+
+<ResultLayout
+  testId={testId}
+  title={`Metrics · ${test.name ?? testId}`}
+  url={test.url}
+  name={test.name}
+  description={test.description}
+  browser={test.browser}
+  browserVersion={harBrowser?.version ?? null}
+  formattedDate={formattedDate}
+  screenshotUrl={screenshotUrl}
+  isUnknown={isUnknown}
+  isUnsafe={isUnsafe}
+  activeTab="metrics"
+>
+  {
+    metrics ? (
+      <AllMetrics metrics={metrics} />
+    ) : (
+      <div class="metrics-unavailable">
+        <p>Metrics unavailable for this test.</p>
+      </div>
+    )
+  }
+</ResultLayout>
+
+<style>
+  .metrics-unavailable {
+    padding: 2.5rem;
+    text-align: center;
+    color: var(--muted);
+    font-size: 0.875rem;
+    background: var(--panel);
+    border: 1px solid var(--border);
+    border-radius: 0.75rem;
+  }
+
+  .metrics-unavailable p {
+    margin: 0;
+  }
+</style>

--- a/telescopetest-io/src/pages/results/[testId]/resources.astro
+++ b/telescopetest-io/src/pages/results/[testId]/resources.astro
@@ -1,0 +1,66 @@
+---
+import ResultLayout from '@/layouts/ResultLayout.astro';
+import ResourcesView from '@/components/Resources.astro';
+import { loadTestResult } from '@/lib/loaders/testResult';
+import { getR2Json } from '@/lib/cache/r2Cache';
+import type { MetricsJson } from '@/lib/types/metrics';
+import type { ResourceTiming } from '@/lib/types/resources';
+
+export const prerender = false;
+
+const result = await loadTestResult(Astro);
+if (!result) {
+  return Astro.redirect('/results');
+}
+
+const { testId, test, isUnknown, isUnsafe, screenshotUrl, harBrowser, formattedDate } = result;
+
+// --- Metrics (needed for navigationTiming) + Resources ---
+const env = (Astro.locals as any).runtime.env;
+const [metrics, resources] = await Promise.all([
+  getR2Json<MetricsJson>(env.RESULTS_BUCKET, `${testId}/metrics.json`),
+  getR2Json<ResourceTiming[]>(env.RESULTS_BUCKET, `${testId}/resources.json`).then(r => r ?? []),
+]);
+---
+
+<ResultLayout
+  testId={testId}
+  title={`Resources · ${test.name ?? testId}`}
+  url={test.url}
+  name={test.name}
+  description={test.description}
+  browser={test.browser}
+  browserVersion={harBrowser?.version ?? null}
+  formattedDate={formattedDate}
+  screenshotUrl={screenshotUrl}
+  isUnknown={isUnknown}
+  isUnsafe={isUnsafe}
+  activeTab="resources"
+>
+  {
+    resources.length > 0 || metrics?.navigationTiming ? (
+      <ResourcesView
+        resources={resources}
+        url={test.url}
+        navigationTiming={metrics?.navigationTiming}
+      />
+    ) : (
+      <div class="resources-unavailable">
+        <p>Resources data unavailable for this test.</p>
+      </div>
+    )
+  }
+</ResultLayout>
+
+<style>
+  .resources-unavailable {
+    padding: 2.5rem;
+    text-align: center;
+    color: var(--muted);
+    font-size: 0.875rem;
+  }
+
+  .resources-unavailable p {
+    margin: 0;
+  }
+</style>

--- a/telescopetest-io/src/pages/results/[testId]/waterfall.astro
+++ b/telescopetest-io/src/pages/results/[testId]/waterfall.astro
@@ -1,0 +1,32 @@
+---
+import ResultLayout from '@/layouts/ResultLayout.astro';
+import WaterfallChart from '@/components/Waterfall.astro';
+import { loadTestResult } from '@/lib/loaders/testResult';
+
+export const prerender = false;
+
+const result = await loadTestResult(Astro);
+if (!result) {
+  return Astro.redirect('/results');
+}
+
+const { testId, test, isUnknown, isUnsafe, screenshotUrl, harBrowser, hasHar, formattedDate } =
+  result;
+---
+
+<ResultLayout
+  testId={testId}
+  title={`Waterfall · ${test.name ?? testId}`}
+  url={test.url}
+  name={test.name}
+  description={test.description}
+  browser={test.browser}
+  browserVersion={harBrowser?.version ?? null}
+  formattedDate={formattedDate}
+  screenshotUrl={screenshotUrl}
+  isUnknown={isUnknown}
+  isUnsafe={isUnsafe}
+  activeTab="waterfall"
+>
+  <WaterfallChart testId={testId} hasHar={hasHar} />
+</ResultLayout>


### PR DESCRIPTION
Dedicated URLs for result tabs with shared layout, R2 cache, and per-tab pages

Split the monolithic result page into separate Astro pages per tab so each tab has its own URL (e.g. `/results/:id/waterfall`, `/results/:id/metrics`).

- Extract shared `ResultLayout.astro` wrapping header, banners, overview, and tab nav
- Extract `loadTestResult()` shared data loader (`lib/loaders/testResult.ts`)
- Add in-memory LRU R2 cache (`lib/cache/r2Cache.ts`) to avoid re-fetching immutable test data across tab navigations within the same Worker isolate
- Convert `Tabs.astro` from client-side button show/hide to `<a>` link navigation
- Create per-tab pages: metrics, waterfall, resources, console under `[testId]/`

Closes #199

✨ AI-assisted