### PR TITLE
Add Astro View Transitions for smooth client-side navigation

### DIFF
--- a/telescopetest-io/src/components/AllMetrics.astro
+++ b/telescopetest-io/src/components/AllMetrics.astro
@@ -901,6 +901,7 @@ const marks = userTiming.filter(u => u.entryType === 'mark');
 </style>
 
 <script>
+  document.addEventListener('astro:page-load', () => {
   const legend = document.getElementById('nt-legend');
   const diagram = document.getElementById('nt-diagram');
   const clearBtn = document.getElementById('nt-legend-clear');
@@ -987,4 +988,5 @@ const marks = userTiming.filter(u => u.entryType === 'mark');
         .forEach(bracket => bracket.classList.remove('nt-tick-bracket--hover'));
     });
   }
+  });
 </script>

--- a/telescopetest-io/src/components/Console.astro
+++ b/telescopetest-io/src/components/Console.astro
@@ -295,9 +295,12 @@ const severityCounts = messages.reduce((acc, msg) => {
 </style>
 
 <script>
+  document.addEventListener('astro:page-load', () => {
   const filtersContainer = document.getElementById('console-filters');
   const tbody = document.getElementById('console-tbody');
   if (filtersContainer && tbody) {
+    // Avoid re-creating buttons if they already exist (e.g. back-navigation)
+    if (filtersContainer.querySelector('.console-filter-btn')) return;
     const countsData = filtersContainer.getAttribute('data-counts');
     const counts = countsData ? JSON.parse(countsData) : {};
     const totalCount = Object.values(counts).reduce((sum: number, count) => sum + (count as number), 0);
@@ -352,4 +355,5 @@ const severityCounts = messages.reduce((acc, msg) => {
       filtersContainer.appendChild(btn);
     });
   }
+  });
 </script>

--- a/telescopetest-io/src/components/Resources.astro
+++ b/telescopetest-io/src/components/Resources.astro
@@ -573,6 +573,7 @@ const hasSegment = (start: number, end: number) => start > 0 && end > 0;
 </style>
 
 <script>
+  document.addEventListener('astro:page-load', () => {
   const resourceRows = document.querySelectorAll('.resource-row');
   resourceRows.forEach((row) => {
     row.addEventListener('click', () => {
@@ -641,5 +642,6 @@ const hasSegment = (start: number, end: number) => start > 0 && end > 0;
     protocolFilter.selectedIndex = -1;
     blockingFilter.checked = false;
     applyFilters();
+  });
   });
 </script>

--- a/telescopetest-io/src/components/Tabs.astro
+++ b/telescopetest-io/src/components/Tabs.astro
@@ -16,7 +16,7 @@ const tabs = [
 ---
 
 <div class="tabs-container">
-  <nav class="tabs-header" aria-label="Result tabs">
+  <nav class="tabs-header" aria-label="Result tabs" transition:name={`tabs-nav-${testId}`} transition:animate="none">
     {
       tabs.map((tab) => (
         <a

--- a/telescopetest-io/src/components/TopNav.astro
+++ b/telescopetest-io/src/components/TopNav.astro
@@ -182,26 +182,28 @@ const navItems = [
     document.cookie = `${name}=${value};expires=${expires};path=/;SameSite=Lax${secure}`;
   }
 
-  const savedTheme = getCookie('theme-override');
+  document.addEventListener('astro:page-load', () => {
+    const savedTheme = getCookie('theme-override');
 
-  if (savedTheme === 'light' || savedTheme === 'dark') {
-    document.documentElement.setAttribute('data-theme-override', savedTheme);
-  }
+    if (savedTheme === 'light' || savedTheme === 'dark') {
+      document.documentElement.setAttribute('data-theme-override', savedTheme);
+    }
 
-  const button = document.querySelector('.theme-toggle') as HTMLButtonElement;
+    const button = document.querySelector('.theme-toggle') as HTMLButtonElement;
 
-  if (button) {
-    button.addEventListener('click', () => {
-      const isDark = document.documentElement.getAttribute(
-        'data-theme-override',
-      )
-        ? document.documentElement.getAttribute('data-theme-override') ===
-          'dark'
-        : window.matchMedia('(prefers-color-scheme: dark)').matches;
+    if (button) {
+      button.addEventListener('click', () => {
+        const isDark = document.documentElement.getAttribute(
+          'data-theme-override',
+        )
+          ? document.documentElement.getAttribute('data-theme-override') ===
+            'dark'
+          : window.matchMedia('(prefers-color-scheme: dark)').matches;
 
-      const newTheme = isDark ? 'light' : 'dark';
-      document.documentElement.setAttribute('data-theme-override', newTheme);
-      setCookie('theme-override', newTheme, 365);
-    });
-  }
+        const newTheme = isDark ? 'light' : 'dark';
+        document.documentElement.setAttribute('data-theme-override', newTheme);
+        setCookie('theme-override', newTheme, 365);
+      });
+    }
+  });
 </script>

--- a/telescopetest-io/src/components/Waterfall.astro
+++ b/telescopetest-io/src/components/Waterfall.astro
@@ -605,10 +605,10 @@ const { testId, hasHar } = Astro.props;
 
   type HarPageTimings = HarPage['pageTimings'];
 
-  // ── State ────────────────────────────────────────────────────────────────
+  // ── State (reset on each page load) ──────────────────────────────────────
   let allEntries: HarEntry[] = [];
   let activeFilters = new Set<string>(['all']);
-  const openPanels = new Map<number, HTMLElement>();
+  let openPanels = new Map<number, HTMLElement>();
   let pageTimings: HarPageTimings = {};
   let totalMs = 0;
   let originMs = 0;
@@ -901,5 +901,14 @@ const { testId, hasHar } = Astro.props;
     }
   }
 
-  init();
+  document.addEventListener('astro:page-load', () => {
+    // Reset state for fresh navigation
+    allEntries = [];
+    activeFilters = new Set(['all']);
+    openPanels = new Map();
+    pageTimings = {};
+    totalMs = 0;
+    originMs = 0;
+    init();
+  });
 </script>

--- a/telescopetest-io/src/layouts/Layout.astro
+++ b/telescopetest-io/src/layouts/Layout.astro
@@ -1,4 +1,6 @@
 ---
+import { ViewTransitions } from 'astro:transitions';
+
 export interface Props {
   title: string;
   description?: string;
@@ -26,6 +28,7 @@ const themeOverride =
     <link rel="icon" type="image/png" href="/favicon.png" />
     <meta name="generator" content={Astro.generator} />
     <title>{title}</title>
+    <ViewTransitions />
   </head>
   <body>
     <slot />

--- a/telescopetest-io/src/layouts/ResultLayout.astro
+++ b/telescopetest-io/src/layouts/ResultLayout.astro
@@ -36,7 +36,7 @@ const {
 ---
 
 <Page title={title}>
-  <div class="detail-header">
+  <div class="detail-header" transition:name={`back-${testId}`} transition:animate="none">
     <a href="/results" class="back-link">← Back to all results</a>
   </div>
   <div class="sections">
@@ -78,7 +78,7 @@ const {
     {
       !isUnsafe && !isUnknown && (
         <>
-          <div class="title-section">
+          <div class="title-section" transition:name={`title-${testId}`} transition:animate="none">
             {name ? <h1>{name}</h1> : <h1>{testId}</h1>}
             {description && (
               <div class="description-details">
@@ -90,7 +90,7 @@ const {
             )}
           </div>
 
-          <section class="overview-section">
+          <section class="overview-section" transition:name={`overview-${testId}`} transition:animate="none">
             <TestInfoPanel
               testId={testId}
               url={url}
@@ -106,7 +106,9 @@ const {
           </section>
 
           <Tabs testId={testId} activeTab={activeTab}>
-            <slot />
+            <div transition:name={`tab-content-${testId}`} transition:animate="fade">
+              <slot />
+            </div>
           </Tabs>
         </>
       )
@@ -241,52 +243,53 @@ const {
 </style>
 
 <script data-test-id={testId}>
-  // AI content rating polling
-  if (document.getElementById('rating-pending')) {
-    const INTERVAL_MS = 2000;
-    const TIMEOUT_MS = 30_000;
-    const start = Date.now();
-    // Extract testId from the data attribute on the script tag
-    const scriptEl = document.querySelector('script[data-test-id]');
-    const testId = scriptEl?.getAttribute('data-test-id');
-    const pendingBanner = document.getElementById('rating-pending');
-    const timeoutBanner = document.getElementById('rating-timeout');
-    async function poll() {
-      if (Date.now() - start >= TIMEOUT_MS) {
-        if (pendingBanner) pendingBanner.style.display = 'none';
-        if (timeoutBanner) timeoutBanner.style.display = '';
-        return;
-      }
-      try {
-        const res = await fetch(`/api/tests/${testId}/rating`);
-        const data = await res.json();
-        if (data.rating === 'safe' || data.rating === 'unsafe') {
-          window.location.reload();
+  document.addEventListener('astro:page-load', () => {
+    // AI content rating polling
+    if (document.getElementById('rating-pending')) {
+      const INTERVAL_MS = 2000;
+      const TIMEOUT_MS = 30_000;
+      const start = Date.now();
+      const scriptEl = document.querySelector('script[data-test-id]');
+      const testId = scriptEl?.getAttribute('data-test-id');
+      const pendingBanner = document.getElementById('rating-pending');
+      const timeoutBanner = document.getElementById('rating-timeout');
+      async function poll() {
+        if (Date.now() - start >= TIMEOUT_MS) {
+          if (pendingBanner) pendingBanner.style.display = 'none';
+          if (timeoutBanner) timeoutBanner.style.display = '';
           return;
         }
-        setTimeout(poll, INTERVAL_MS);
-      } catch {
-        setTimeout(poll, INTERVAL_MS);
+        try {
+          const res = await fetch(`/api/tests/${testId}/rating`);
+          const data = await res.json();
+          if (data.rating === 'safe' || data.rating === 'unsafe') {
+            window.location.reload();
+            return;
+          }
+          setTimeout(poll, INTERVAL_MS);
+        } catch {
+          setTimeout(poll, INTERVAL_MS);
+        }
       }
+      setTimeout(poll, INTERVAL_MS);
     }
-    setTimeout(poll, INTERVAL_MS);
-  }
-  // Description toggle
-  const toggle = document.querySelector('.description-toggle');
-  const text = document.querySelector('.description-text');
-  if (toggle && text) {
-    toggle.addEventListener('click', () => {
-      const expanded = toggle.getAttribute('aria-expanded') === 'true';
-      const el = /** @type {HTMLElement} */ (text);
-      if (expanded) {
-        el.style.overflow = '';
-        el.style.webkitLineClamp = '';
-      } else {
-        el.style.overflow = 'visible';
-        el.style.webkitLineClamp = 'unset';
-      }
-      toggle.setAttribute('aria-expanded', String(!expanded));
-      toggle.textContent = expanded ? 'more' : 'less';
-    });
-  }
+    // Description toggle
+    const toggle = document.querySelector('.description-toggle');
+    const text = document.querySelector('.description-text');
+    if (toggle && text) {
+      toggle.addEventListener('click', () => {
+        const expanded = toggle.getAttribute('aria-expanded') === 'true';
+        const el = /** @type {HTMLElement} */ (text);
+        if (expanded) {
+          el.style.overflow = '';
+          el.style.webkitLineClamp = '';
+        } else {
+          el.style.overflow = 'visible';
+          el.style.webkitLineClamp = 'unset';
+        }
+        toggle.setAttribute('aria-expanded', String(!expanded));
+        toggle.textContent = expanded ? 'more' : 'less';
+      });
+    }
+  });
 </script>

--- a/telescopetest-io/src/pages/index.astro
+++ b/telescopetest-io/src/pages/index.astro
@@ -1,4 +1,5 @@
 ---
+import { ViewTransitions } from 'astro:transitions';
 const year = new Date().getFullYear();
 ---
 
@@ -17,6 +18,7 @@ const year = new Date().getFullYear();
       content="Diagnostic performance testing across Chrome, Firefox, Safari, and Edge. Built by Cloudflare."
     />
     <link rel="icon" type="image/png" href="/favicon.png" />
+    <ViewTransitions />
     <style>
       * {
         margin: 0;

--- a/telescopetest-io/src/pages/results.astro
+++ b/telescopetest-io/src/pages/results.astro
@@ -178,22 +178,21 @@ export const prerender = false;
 </style>
 
 <script>
-  const buttons = document.querySelectorAll('.toggle-button');
-  const container = document.querySelector('.results-container');
-  if (buttons.length && container) {
-    buttons.forEach(button => {
-      button.addEventListener('click', () => {
-        const view = button.getAttribute('data-view');
-        if (!view) return;
-        // Update active state
-        buttons.forEach(btn => btn.classList.remove('active'));
-        button.classList.add('active');
-        // Update layout
-        container.setAttribute('data-layout', view);
-        // Save to both localStorage and cookie
-        localStorage.setItem('resultsView', view);
-        document.cookie = `resultsView=${view};path=/;max-age=31536000;SameSite=Lax`;
+  document.addEventListener('astro:page-load', () => {
+    const buttons = document.querySelectorAll('.toggle-button');
+    const container = document.querySelector('.results-container');
+    if (buttons.length && container) {
+      buttons.forEach(button => {
+        button.addEventListener('click', () => {
+          const view = button.getAttribute('data-view');
+          if (!view) return;
+          buttons.forEach(btn => btn.classList.remove('active'));
+          button.classList.add('active');
+          container.setAttribute('data-layout', view);
+          localStorage.setItem('resultsView', view);
+          document.cookie = `resultsView=${view};path=/;max-age=31536000;SameSite=Lax`;
+        });
       });
-    });
-  }
+    }
+  });
 </script>

--- a/telescopetest-io/src/pages/upload.astro
+++ b/telescopetest-io/src/pages/upload.astro
@@ -260,7 +260,9 @@ import Page from '@/layouts/Page.astro';
 </style>
 
 <script>
+  document.addEventListener('astro:page-load', () => {
   const form = document.getElementById('upload-form') as HTMLFormElement;
+  if (!form) return;
   const fileInput = document.getElementById('file-upload') as HTMLInputElement;
   const fileUploadArea = document.getElementById(
     'file-upload-area',
@@ -402,4 +404,5 @@ import Page from '@/layouts/Page.astro';
     fileName.textContent = `Selected: ${name}`;
     fileName.style.display = 'block';
   }
+  });
 </script>


### PR DESCRIPTION
## Summary

- Enables Astro's built-in View Transitions (`<ViewTransitions />`) across the entire site to eliminate full-page reloads when navigating between pages
- Adds `transition:name` / `transition:animate` directives to the shared ResultLayout so the header, overview, and tab nav stay stable while tab content crossfades
- Wraps all interactive `<script>` bodies in `astro:page-load` event handlers so event listeners re-bind after client-side DOM swaps

## Depends on

This PR is based on the `199-separate-pages` branch (dedicated tab URLs). It should be merged after that branch lands.

## Details

**Problem:** With the new per-tab URL structure, every tab switch is a full page navigation. The entire page (header, overview panel, screenshot, tab nav) flashes and re-renders even though only the tab content changes.

**Solution:** Astro View Transitions intercept link clicks and perform client-side DOM diffing instead of full reloads. Elements with matching `transition:name` attributes morph in place; the tab content area uses `transition:animate="fade"` for a smooth crossfade.

**Scripts fix:** Astro's client router only executes `<script>` modules once. After a soft navigation, the DOM is swapped but scripts don't re-run, leaving new elements without event listeners. All interactive scripts are now wrapped in `document.addEventListener('astro:page-load', ...)` which fires on initial load AND after every client-side navigation.

### Files changed

| File | Change |
|------|--------|
| `Layout.astro` | Added `<ViewTransitions />` to `<head>` |
| `index.astro` | Added `<ViewTransitions />` (standalone page) |
| `ResultLayout.astro` | `transition:name`/`transition:animate` on header, title, overview, tab content |
| `Tabs.astro` | `transition:name` on tab nav |
| `TopNav.astro` | `astro:page-load` wrapper for theme toggle |
| `results.astro` | `astro:page-load` wrapper for list/grid switcher |
| `upload.astro` | `astro:page-load` wrapper for upload form |
| `AllMetrics.astro` | `astro:page-load` wrapper for legend/diagram interactions |
| `Console.astro` | `astro:page-load` wrapper + duplicate button guard |
| `Resources.astro` | `astro:page-load` wrapper for filters |
| `Waterfall.astro` | `astro:page-load` wrapper + state reset on navigation |

Closes #199 

✨ AI-assisted