### PR TITLE
Telescopetest-io: Fix 500 errors bug from per-asset `content_rating` check 

### DIFF
--- a/telescopetest-io/src/pages/api/tests/[testId]/[...filename].ts
+++ b/telescopetest-io/src/pages/api/tests/[testId]/[...filename].ts
@@ -8,7 +8,7 @@ import { isValidTestId, isExpectedTelescopeFile } from '@/lib/utils/security';
 /**
  * Check test rating with cache
  * Cache key format: https://rating/{testId}
- * TTL: 1 hour via Cache-Control header
+ * TTL: immutable (ratings never change once final)
  * Only caches final ratings (SAFE or UNSAFE), not UNKNOWN or IN_PROGRESS
  */
 async function checkTestRating(
@@ -17,8 +17,8 @@ async function checkTestRating(
 ): Promise<string> {
   const cacheKey = `https://rating/${testId}`;
   // try cache read
+  const cache = await caches.open('rating-cache');
   try {
-    const cache = await caches.open('rating-cache');
     const cached = await cache.match(cacheKey);
     if (cached) {
       return await cached.text();
@@ -37,11 +37,10 @@ async function checkTestRating(
     test.rating === ContentRating.SAFE || test.rating === ContentRating.UNSAFE;
   if (isFinalRating) {
     try {
-      const cache = await caches.open('rating-cache');
       await cache.put(
         cacheKey,
         new Response(test.rating, {
-          headers: { 'Cache-Control': 'public, max-age=3600' },
+          headers: { 'Cache-Control': 'public, max-age=31536000, immutable' },
         }),
       );
     } catch (error) {


### PR DESCRIPTION
Tries to address #221. Check the comment in that issue for how I debugged (I used staging and staging logs). 

The problem (from AI): When a user loads a test page with 30+ assets (images, HAR files, etc.), each asset makes a separate database query to check if the test is safe, causing 30+ concurrent DB queries that overwhelm D1 and cause intermittent 500 errors.

First commit (1332a95) was testing with `Promise.race()`, for some reason setting prisma call timeout to 500 ms seemed to always keep the Prisma queries from hanging. But I don't really know or like this function so I discarded this. 

Second commit (**current solution**) (53b7cfa) uses Cloudflare's Cache API (built into Workers runtime, see caches.open() in the [Workers docs](https://developers.cloudflare.com/workers/runtime-apis/cache/)) to cache the rating check result at Cloudflare's edge (server-side caching). Requesting one asset's `content_rating` caches the entire test's `content_rating`. We should ONLY cache `content_rating` = 'UNSAFE' or `content_rating` = 'SAFE' in order to not cache an intermediate state.
- Some caveats (from AI) : 
    - Different regions: Each datacenter has its own cache, so London's first request queries DB, New York's first request queries DB, but then each region's subsequent requests hit their local cache (this is actually good - geographically distributed caching)

**EDIT: this is a temporary fix, cache is likely not the best solution.**


Another possible solution is to use multiple R2 buckets. May explore, but adds complexity, also R2 costs (R2 more expensive), also might still require multiple D1 calls. Not sure, need to think about it ... 