### PR TITLE
Telescopetest-io: fix deploy.yml failure from production build 

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -41,6 +41,9 @@ jobs:
       - name: build astro site
         working-directory: ./telescopetest-io
         run: CLOUDFLARE_ENV=production npx astro build
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+
       - name: deploy to cloudflare workers
         working-directory: ./telescopetest-io
         run: npx wrangler deploy --env production


### PR DESCRIPTION
Add cloudflare-api-token (needed for production env) to 'build astro site' command in workflow. I missed this in the review for #223, sorry! 

Should hopefully fix this issue: https://github.com/cloudflare/telescope/actions/runs/23559697085/job/68595963918#step:7:17