### PR TITLE
Use device defaultBrowserType as browser default when -b is not provided

### DIFF
--- a/packages/telescope/__tests__/emulation.test.ts
+++ b/packages/telescope/__tests__/emulation.test.ts
@@ -1,9 +1,14 @@
 import fs from 'fs';
+import { devices } from 'playwright';
 import type { SuccessfulTestResult } from '../src/index.js';
 import { launchTest } from '../src/index.js';
 import { BrowserConfig } from '../src/browsers.js';
 import { normalizeCLIConfig } from '../src/config.js';
-import type { LaunchOptions, BrowserConfigOptions } from '../src/types.js';
+import type {
+  LaunchOptions,
+  BrowserConfigOptions,
+  CustomDeviceDescriptor,
+} from '../src/types.js';
 import { describe, it, expect, beforeAll } from 'vitest';
 
 const browsers = BrowserConfig.getBrowsers();
@@ -177,4 +182,117 @@ describe.each(browsers)('Device Emulation Tests', browser => {
       });
     },
   );
+});
+
+// Expected engine for each device's defaultBrowserType
+const deviceBrowserExpectations: {
+  device: string;
+  expectedBrowser: string;
+  expectedEngine: string;
+}[] = [
+  { device: 'iPhone 15', expectedBrowser: 'safari', expectedEngine: 'webkit' },
+  { device: 'Pixel 7', expectedBrowser: 'chrome', expectedEngine: 'chromium' },
+  {
+    device: 'Desktop Safari',
+    expectedBrowser: 'safari',
+    expectedEngine: 'webkit',
+  },
+  {
+    device: 'Desktop Chrome',
+    expectedBrowser: 'chrome',
+    expectedEngine: 'chromium',
+  },
+  {
+    device: 'Desktop Firefox',
+    expectedBrowser: 'firefox',
+    expectedEngine: 'firefox',
+  },
+];
+
+describe('Device default browser resolution', () => {
+  describe.each(deviceBrowserExpectations)(
+    'Device only (no -b): $device',
+    ({ device, expectedBrowser, expectedEngine }) => {
+      let config_options: LaunchOptions;
+      let config: BrowserConfigOptions;
+
+      beforeAll(() => {
+        config_options = normalizeCLIConfig({
+          device,
+          url: '../tests/sandbox/index.html',
+        });
+        config = new BrowserConfig().getBrowserConfig(
+          config_options.browser!,
+          config_options,
+        );
+      });
+
+      it(`resolves browser to "${expectedBrowser}"`, () => {
+        expect(config_options.browser).toBe(expectedBrowser);
+      });
+
+      it(`resolves engine to "${expectedEngine}"`, () => {
+        expect(config.engine).toBe(expectedEngine);
+      });
+    },
+  );
+
+  describe.each(deviceBrowserExpectations)(
+    'Device + explicit -b override: $device',
+    ({ device }) => {
+      let config_options: LaunchOptions;
+      let config: BrowserConfigOptions;
+
+      beforeAll(() => {
+        config_options = normalizeCLIConfig({
+          device,
+          browser: 'firefox',
+          url: '../tests/sandbox/index.html',
+        });
+        config = new BrowserConfig().getBrowserConfig(
+          config_options.browser!,
+          config_options,
+        );
+      });
+
+      it('explicit -b overrides device default browser', () => {
+        expect(config_options.browser).toBe('firefox');
+      });
+
+      it('engine matches the explicit browser, not the device', () => {
+        expect(config.engine).toBe('firefox');
+      });
+    },
+  );
+
+  describe('Browser only (no device)', () => {
+    it('uses the provided browser', () => {
+      const config_options = normalizeCLIConfig({
+        browser: 'safari',
+        url: '../tests/sandbox/index.html',
+      });
+      expect(config_options.browser).toBe('safari');
+
+      const config = new BrowserConfig().getBrowserConfig(
+        config_options.browser!,
+        config_options,
+      );
+      expect(config.engine).toBe('webkit');
+    });
+  });
+
+  describe('Neither device nor browser', () => {
+    it('defaults to chrome/chromium', () => {
+      const config_options = normalizeCLIConfig({
+        url: '../tests/sandbox/index.html',
+      });
+      expect(config_options.browser).toBe('chrome');
+
+      const config = new BrowserConfig().getBrowserConfig(
+        config_options.browser!,
+        config_options,
+      );
+      expect(config.engine).toBe('chromium');
+    });
+  });
 });

--- a/packages/telescope/__tests__/emulation.test.ts
+++ b/packages/telescope/__tests__/emulation.test.ts
@@ -1,5 +1,4 @@
 import fs from 'fs';
-import { devices } from 'playwright';
 import type { SuccessfulTestResult } from '../src/index.js';
 import { launchTest } from '../src/index.js';
 import { BrowserConfig } from '../src/browsers.js';

--- a/packages/telescope/src/config.ts
+++ b/packages/telescope/src/config.ts
@@ -148,13 +148,16 @@ export function normalizeCLIConfig(options: CLIOptions): LaunchOptions {
     config.device = playwrightDevice as CustomDeviceDescriptor;
   }
 
-  // resolve browser: explicit -b value > device's defaultBrowserType > default
-  config.browser =
-    config.browser ??
-    (config.device
-      ? ENGINE_TO_BROWSER_NAME[config.device.defaultBrowserType]
-      : undefined) ??
-    DEFAULT_OPTIONS.browser;
+  // resolve browser: device default first, explicit -b overrides, then fallback
+  if (config.device) {
+    config.browser = ENGINE_TO_BROWSER_NAME[config.device.defaultBrowserType];
+  }
+
+  if (options.browser) {
+    config.browser = options.browser as BrowserName;
+  }
+
+  config.browser = config.browser ?? DEFAULT_OPTIONS.browser;
 
   return config;
 }

--- a/packages/telescope/src/config.ts
+++ b/packages/telescope/src/config.ts
@@ -4,12 +4,23 @@ import type {
   ConnectionType,
   BrowserName,
   CustomDeviceDescriptor,
+  PlaywrightEngine,
 } from './types.js';
 import { parseUnknown } from './validation.js';
 import { StringArraySchema } from './schemas.js';
 
 import { DEFAULT_OPTIONS } from './defaultOptions.js';
 import { devices } from 'playwright';
+
+/**
+ * Maps a Playwright engine name to the corresponding Telescope BrowserName.
+ * Used to derive a default browser from a device's defaultBrowserType.
+ */
+const ENGINE_TO_BROWSER_NAME: Record<PlaywrightEngine, BrowserName> = {
+  chromium: 'chrome',
+  firefox: 'firefox',
+  webkit: 'safari',
+};
 
 /**
  * Normalize CLI options into a typed LaunchOptions config.
@@ -26,7 +37,7 @@ import { devices } from 'playwright';
 export function normalizeCLIConfig(options: CLIOptions): LaunchOptions {
   const config: LaunchOptions = {
     url: options.url,
-    browser: (options.browser as BrowserName) || DEFAULT_OPTIONS.browser,
+    browser: options.browser as BrowserName | undefined,
     width: options.width,
     height: options.height,
     frameRate: options.frameRate ?? DEFAULT_OPTIONS.frameRate,
@@ -136,6 +147,14 @@ export function normalizeCLIConfig(options: CLIOptions): LaunchOptions {
     // the 'device' in config is the playwright object with device metadata
     config.device = playwrightDevice as CustomDeviceDescriptor;
   }
+
+  // resolve browser: explicit -b value > device's defaultBrowserType > default
+  config.browser =
+    config.browser ??
+    (config.device
+      ? ENGINE_TO_BROWSER_NAME[config.device.defaultBrowserType]
+      : undefined) ??
+    DEFAULT_OPTIONS.browser;
 
   return config;
 }

--- a/packages/telescope/src/index.ts
+++ b/packages/telescope/src/index.ts
@@ -191,15 +191,17 @@ export default function browserAgent(): void {
     .description('Cross-browser synthetic testing agent')
     .requiredOption('-u, --url <url>', 'URL to run tests against')
     .addOption(
-      new Option('-b, --browser <browser_name>', 'Browser to run tests with')
-        .choices([
-          'chrome',
-          'chrome-beta',
-          'canary',
-          'edge',
-          'safari',
-          'firefox',
-        ]),
+      new Option(
+        '-b, --browser <browser_name>',
+        'Browser to run tests with. Defaults to chrome, or to the device default browser engine if --device is provided.',
+      ).choices([
+        'chrome',
+        'chrome-beta',
+        'canary',
+        'edge',
+        'safari',
+        'firefox',
+      ]),
     )
     .addOption(
       new Option(
@@ -373,7 +375,7 @@ export default function browserAgent(): void {
     .addOption(
       new Option(
         '--device <string>',
-        'Device to use device emulation (viewport size, DPR, touch events); devices are based on the Playwright device list (see https://github.com/microsoft/playwright/blob/main/packages/playwright-core/src/server/deviceDescriptorsSource.json)',
+        'Device to use for device emulation (viewport size, DPR, touch events). Also sets the default browser engine unless overridden with -b. Devices are based on the Playwright device list (see https://github.com/microsoft/playwright/blob/main/packages/playwright-core/src/server/deviceDescriptorsSource.json)',
       ),
     )
     .parse(process.argv);

--- a/packages/telescope/src/index.ts
+++ b/packages/telescope/src/index.ts
@@ -192,7 +192,6 @@ export default function browserAgent(): void {
     .requiredOption('-u, --url <url>', 'URL to run tests against')
     .addOption(
       new Option('-b, --browser <browser_name>', 'Browser to run tests with')
-        .default(DEFAULT_OPTIONS.browser)
         .choices([
           'chrome',
           'chrome-beta',


### PR DESCRIPTION
- Updates default evaluation for Browser to assign defaults for Browser in config.ts after device emulation evaluation

### Device only — should use device's default browser engine
npx . -u https://www.example.com --device "iPhone 15"
npx . -u https://www.example.com --device "Pixel 7"

### Device + explicit browser — browser should override device default
npx . -u https://www.example.com --device "iPhone 15" -b chrome

### Browser only — no device
npx . -u https://www.example.com -b firefox

### Neither device nor browser — should default to chrome/chromium
npx . -u https://www.example.com