### PR TITLE
Update workflow to release both telescope and waterfall modules

### DIFF
--- a/.changeset/tough-ends-pump.md
+++ b/.changeset/tough-ends-pump.md
@@ -1,0 +1,5 @@
+---
+"@cloudflare/waterfall": patch
+---
+
+Initial release of the @cloudflare/waterfall component with server-side rendering, CSS styling and JS Web Component mounting for interactivity

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,6 +35,12 @@ jobs:
       - name: Lint telescope
         run: npm run lint -w packages/telescope
 
+      - name: Build waterfall
+        run: npm run build -w packages/waterfall
+
+      - name: Typecheck waterfall
+        run: npm run typecheck -w packages/waterfall
+
   release:
     name: Release
     needs: check
@@ -63,23 +69,40 @@ jobs:
       - name: Build telescope
         run: npm run build -w packages/telescope
 
-      # Compute the next version that `changeset version` would produce. Used
-      # to inject the version into the PR title and commit message below.
-      # Falls back to "next" when no pending changesets exist.
-      - name: Compute next version
+      - name: Build waterfall
+        run: npm run build -w packages/waterfall
+
+      # Compute the next versions that `changeset version` would produce for
+      # each published package. Used to inject versions into the PR title and
+      # commit message below. Falls back to "next" when no pending changesets
+      # exist for a given package.
+      - name: Compute next versions
         id: next_version
         run: |
           npx changeset status --output=release-status.json || true
           if [ -f release-status.json ]; then
-            VERSION=$(node -e "const r=require('./release-status.json').releases||[]; const t=r.find(x=>x.name==='@cloudflare/telescope'); console.log(t?t.newVersion:'')")
+            TELESCOPE_VERSION=$(node -e "const r=require('./release-status.json').releases||[]; const t=r.find(x=>x.name==='@cloudflare/telescope'); console.log(t?t.newVersion:'')")
+            WATERFALL_VERSION=$(node -e "const r=require('./release-status.json').releases||[]; const t=r.find(x=>x.name==='@cloudflare/waterfall'); console.log(t?t.newVersion:'')")
           else
-            VERSION=""
+            TELESCOPE_VERSION=""
+            WATERFALL_VERSION=""
           fi
-          if [ -z "$VERSION" ]; then
-            VERSION="next"
+
+          PARTS=()
+          if [ -n "$TELESCOPE_VERSION" ]; then
+            PARTS+=("telescope@$TELESCOPE_VERSION")
           fi
-          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
-          echo "Next telescope version: $VERSION"
+          if [ -n "$WATERFALL_VERSION" ]; then
+            PARTS+=("waterfall@$WATERFALL_VERSION")
+          fi
+          if [ ${#PARTS[@]} -eq 0 ]; then
+            TITLE="next"
+          else
+            TITLE=$(IFS=', '; echo "${PARTS[*]}")
+          fi
+
+          echo "title=$TITLE" >> "$GITHUB_OUTPUT"
+          echo "Next release: $TITLE"
 
       - name: Create Release Pull Request or Publish to npm
         id: changesets
@@ -87,8 +110,8 @@ jobs:
         with:
           version: npm run version-packages
           publish: npx changeset publish
-          title: 'Publish ${{ steps.next_version.outputs.version }}'
-          commit: 'Publish ${{ steps.next_version.outputs.version }}'
+          title: 'Publish ${{ steps.next_version.outputs.title }}'
+          commit: 'Publish ${{ steps.next_version.outputs.title }}'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -98,7 +98,11 @@ jobs:
           if [ ${#PARTS[@]} -eq 0 ]; then
             TITLE="next"
           else
-            TITLE=$(IFS=', '; echo "${PARTS[*]}")
+            # Join array elements with ", ". Note: "${PARTS[*]}" with IFS=', '
+            # would only use the first IFS character as the separator, so we
+            # use printf and strip the trailing separator instead.
+            TITLE=$(printf '%s, ' "${PARTS[@]}")
+            TITLE=${TITLE%, }
           fi
 
           echo "title=$TITLE" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,8 +23,8 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: '24'
-          cache: 'npm'
+          node-version: "24"
+          cache: "npm"
 
       - name: Install dependencies (skip postinstall)
         run: npm ci --ignore-scripts
@@ -37,9 +37,6 @@ jobs:
 
       - name: Build waterfall
         run: npm run build -w packages/waterfall
-
-      - name: Typecheck waterfall
-        run: npm run typecheck -w packages/waterfall
 
   release:
     name: Release
@@ -59,9 +56,9 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: '24'
-          cache: 'npm'
-          registry-url: 'https://registry.npmjs.org'
+          node-version: "24"
+          cache: "npm"
+          registry-url: "https://registry.npmjs.org"
 
       - name: Install dependencies (skip postinstall)
         run: npm ci --ignore-scripts
@@ -114,9 +111,9 @@ jobs:
         with:
           version: npm run version-packages
           publish: npx changeset publish
-          title: 'Publish ${{ steps.next_version.outputs.title }}'
-          commit: 'Publish ${{ steps.next_version.outputs.title }}'
+          title: "Publish ${{ steps.next_version.outputs.title }}"
+          commit: "Publish ${{ steps.next_version.outputs.title }}"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-          NPM_CONFIG_PROVENANCE: 'true'
+          NPM_CONFIG_PROVENANCE: "true"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -75,7 +75,7 @@ jobs:
       # Compute the next versions that `changeset version` would produce for
       # each published package. Used to inject versions into the PR title and
       # commit message below. Falls back to "next" when no pending changesets
-      # exist for a given package.
+      # exist for any package.
       - name: Compute next versions
         id: next_version
         run: |


### PR DESCRIPTION
Extends `.github/workflows/release.yml` so the `@cloudflare/waterfall` package is built and published alongside `@cloudflare/telescope` via changesets. Each package versions and publishes independently based on its own changesets — they are not linked or fixed.

## Changes to `release.yml`

**Pre-release Checks job**
- Build waterfall (`npm run build -w packages/waterfall`)
- Typecheck waterfall (`npm run typecheck -w packages/waterfall`) — waterfall has no `lint` script, so we use the equivalent `typecheck` it does have

**Release job**
- Build waterfall before publish, so `npx changeset publish` has compiled `dist/` output to upload
- Extend the *Compute next versions* step to look up both `@cloudflare/telescope` and `@cloudflare/waterfall` from changeset status, producing a combined PR/commit title like `Publish telescope@1.2.3, waterfall@0.2.0`. Either package can release independently — if only one has a pending changeset, the title only mentions that package; if neither does, it falls back to `next`.

## Changeset

Also includes `.changeset/tough-ends-pump.md`, a `patch` changeset for `@cloudflare/waterfall` that will trigger the initial publish to npm once this PR (and the follow-up "Version Packages" PR opened by changesets/action) is merged:

> Initial release of the @cloudflare/waterfall component with server-side rendering, CSS styling and JS Web Component mounting for interactivity

## Why this works for separate releases

- `.changeset/config.json` already includes `@cloudflare/waterfall` (only `@cloudflare/telescope-web` is in `ignore`), and `fixed`/`linked` are empty — so the two packages version and publish independently.
- `npx changeset publish` already handles publishing both to npm with provenance via `NPM_CONFIG_PROVENANCE`; no additional publish step is needed.

## Notes

- Waterfall's current version is `0.1.0` and has never been published. After this PR merges, changesets/action will open a "Version Packages" PR bumping waterfall to `0.1.1`; merging that PR triggers the first npm publish. The npm token used must have publish rights for `@cloudflare/waterfall`.
- Waterfall's `package.json` has no `publishConfig.access`, but `.changeset/config.json` sets `"access": "public"` globally, so it will publish as public.