### PR TITLE
agentExtra: Append with whitespace

### DIFF
--- a/packages/telescope/src/testRunner.ts
+++ b/packages/telescope/src/testRunner.ts
@@ -259,7 +259,8 @@ class TestRunner {
       await tmpbrowser.close();
 
       this.selectedBrowser.userAgent = originalUserAgent.concat(
-        this.options.agentExtra,
+        " ",
+        this.options.agentExtra.trim(),
       );
     }
 


### PR DESCRIPTION
I noticed that `--agentExtra XYZ` will append to the `User-Agent` without any whitespace.

Example:

```
Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) ... Safari/537.36XYZ
```

I would have expected the `--agentExtra` token would be applied as another "token" in the UA (instead of at the end of the last character, e.g. Safari version above):

```
Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) ... Safari/537.36 XYZ
```

This appends `--agentExtra` with a whitespace first (and trimmed in case it was wrapped in whitespace before).
