### PR TITLE
Deploy waterfall demo site to waterfall.telescopetest.io

### DIFF
--- a/.github/workflows/deploy-waterfall-site.yml
+++ b/.github/workflows/deploy-waterfall-site.yml
@@ -31,8 +31,6 @@ jobs:
       - name: build demo site
         working-directory: ./packages/waterfall
         run: npm run build:demo
-        env:
-          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
 
       - name: deploy to cloudflare workers
         working-directory: ./packages/waterfall

--- a/.github/workflows/deploy-waterfall-site.yml
+++ b/.github/workflows/deploy-waterfall-site.yml
@@ -1,0 +1,41 @@
+name: Deploy waterfall.telescopetest.io production site (no-op on forks)
+permissions:
+  contents: read
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - "packages/waterfall/**"
+
+jobs:
+  deploy:
+    if: github.repository == 'cloudflare/telescope'
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout code
+        uses: actions/checkout@v6
+
+      - name: setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: "lts/krypton"
+          cache: "npm"
+          cache-dependency-path: "./packages/waterfall/package-lock.json"
+
+      - name: install dependencies
+        working-directory: ./packages/waterfall
+        run: npm ci
+
+      - name: build demo site
+        working-directory: ./packages/waterfall
+        run: npm run build:demo
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+
+      - name: deploy to cloudflare workers
+        working-directory: ./packages/waterfall
+        run: npx wrangler deploy
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}

--- a/packages/waterfall/.prettierignore
+++ b/packages/waterfall/.prettierignore
@@ -1,1 +1,2 @@
 dist/
+dist-demo/

--- a/packages/waterfall/README.md
+++ b/packages/waterfall/README.md
@@ -4,6 +4,8 @@ A self-contained, framework-free web component that renders an HTTP Archive
 (HAR) waterfall chart. Styling lives in a standalone `waterfall.css` — link it
 in `<head>` and the chart renders correctly with or without JavaScript.
 
+**Live demo:** [waterfall.telescopetest.io](https://waterfall.telescopetest.io)
+
 ## Usage
 
 ### 1. Static (CSS-only, no JavaScript)

--- a/packages/waterfall/package.json
+++ b/packages/waterfall/package.json
@@ -36,7 +36,7 @@
   },
   "scripts": {
     "build": "tsc && vite build --config vite.lib.config.ts && chmod +x dist/cli.js",
-    "build:demo": "npm run gen-demo && vite build",
+    "build:demo": "npm run build && npm run gen-demo && vite build",
     "predev": "npm run build",
     "prestart": "npm run build",
     "start": "vite",
@@ -46,7 +46,7 @@
     "format": "prettier --write .",
     "format:check": "prettier --check .",
     "test": "vitest run",
-    "clean": "rm -rf dist node_modules"
+    "clean": "rm -rf dist dist-demo node_modules"
   },
   "devDependencies": {
     "playwright": "^1.60.0",

--- a/packages/waterfall/public/demo.css
+++ b/packages/waterfall/public/demo.css
@@ -86,6 +86,41 @@ waterfall-chart {
   pointer-events: none;
 }
 
+/* ── Header actions (right side: GitHub link + theme toggle) ─────────────── */
+
+.header-actions {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  flex-shrink: 0;
+}
+
+/* ── GitHub link ─────────────────────────────────────────────────────────── */
+
+.github-link {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 2rem;
+  height: 2rem;
+  border-radius: 0.375rem;
+  color: #374151;
+  text-decoration: none;
+  transition:
+    background 0.2s,
+    color 0.2s;
+}
+
+.github-link:hover,
+.github-link:focus-visible {
+  background: #e5e7eb;
+  color: #111827;
+}
+
+.github-link__icon {
+  display: block;
+}
+
 /* ── Shared button and input styles (interactive pages) ──────────────────── */
 
 button {
@@ -256,6 +291,16 @@ input[type='url'] {
     .enhance-status {
       color: #9ca3af;
     }
+
+    .github-link {
+      color: #d1d5db;
+    }
+
+    .github-link:hover,
+    .github-link:focus-visible {
+      background: #374151;
+      color: #f9fafb;
+    }
   }
 }
 
@@ -323,6 +368,16 @@ input[type='url'] {
 
 [data-theme='dark'] .enhance-status {
   color: #9ca3af;
+}
+
+[data-theme='dark'] .github-link {
+  color: #d1d5db;
+}
+
+[data-theme='dark'] .github-link:hover,
+[data-theme='dark'] .github-link:focus-visible {
+  background: #374151;
+  color: #f9fafb;
 }
 
 /* ── Theme toggle (in header, right side) ────────────────────────────────── */

--- a/packages/waterfall/public/index.html
+++ b/packages/waterfall/public/index.html
@@ -23,18 +23,42 @@
           <li><a href="src-attr.html">src attribute</a></li>
         </ul>
       </nav>
-      <label
-        class="theme-toggle"
-        aria-label="Toggle colour theme"
-        title="Toggle colour theme"
-      >
-        <span class="theme-toggle__icon">☀️</span>
-        <input type="checkbox" id="theme-btn" />
-        <span class="theme-toggle__track"
-          ><span class="theme-toggle__knob"></span
-        ></span>
-        <span class="theme-toggle__icon">🌙</span>
-      </label>
+      <div class="header-actions">
+        <a
+          class="github-link"
+          href="https://github.com/cloudflare/telescope/tree/main/packages/waterfall#readme"
+          target="_blank"
+          rel="noopener noreferrer"
+          aria-label="View on GitHub"
+          title="View on GitHub"
+        >
+          <svg
+            class="github-link__icon"
+            xmlns="http://www.w3.org/2000/svg"
+            viewBox="0 0 24 24"
+            width="20"
+            height="20"
+            aria-hidden="true"
+          >
+            <path
+              fill="currentColor"
+              d="M12 .5C5.73.5.5 5.74.5 12.02c0 5.08 3.29 9.39 7.86 10.91.58.11.79-.25.79-.56 0-.28-.01-1.02-.02-2-3.2.7-3.87-1.54-3.87-1.54-.52-1.33-1.28-1.68-1.28-1.68-1.04-.71.08-.7.08-.7 1.16.08 1.77 1.19 1.77 1.19 1.03 1.76 2.7 1.25 3.36.96.1-.75.4-1.25.73-1.54-2.55-.29-5.24-1.28-5.24-5.69 0-1.26.45-2.29 1.18-3.09-.12-.29-.51-1.46.11-3.05 0 0 .97-.31 3.18 1.18a11 11 0 0 1 2.9-.39c.98 0 1.97.13 2.9.39 2.2-1.49 3.17-1.18 3.17-1.18.63 1.59.24 2.76.12 3.05.74.8 1.18 1.83 1.18 3.09 0 4.42-2.69 5.39-5.26 5.68.41.35.77 1.05.77 2.11 0 1.53-.01 2.76-.01 3.13 0 .31.21.68.8.56 4.56-1.53 7.85-5.83 7.85-10.91C23.5 5.74 18.27.5 12 .5z"
+            />
+          </svg>
+        </a>
+        <label
+          class="theme-toggle"
+          aria-label="Toggle colour theme"
+          title="Toggle colour theme"
+        >
+          <span class="theme-toggle__icon">☀️</span>
+          <input type="checkbox" id="theme-btn" />
+          <span class="theme-toggle__track"
+            ><span class="theme-toggle__knob"></span
+          ></span>
+          <span class="theme-toggle__icon">🌙</span>
+        </label>
+      </div>
     </header>
 
     <h1>Progressive enhancement</h1>
@@ -56,33 +80,45 @@
 
     <waterfall-chart id="wf">
       <!-- wf-demo-start -->
-      <div class="wf-toolbar">
+    <div class="wf-toolbar">
         <div
           class="wf-legend-group wf-filters"
           role="group"
           aria-label="Filter by resource type"
         >
-          <button type="button" class="wf-filter-btn active">all</button>
-          <button type="button" class="wf-filter-btn">
-            <span class="wf-swatch wf-swatch--thick wf-swatch--html"></span>HTML
-          </button>
-          <button type="button" class="wf-filter-btn">
-            <span class="wf-swatch wf-swatch--thick wf-swatch--js"></span>JS
-          </button>
-          <button type="button" class="wf-filter-btn">
-            <span class="wf-swatch wf-swatch--thick wf-swatch--css"></span>CSS
-          </button>
-          <button type="button" class="wf-filter-btn">
-            <span class="wf-swatch wf-swatch--thick wf-swatch--image"></span
-            >image
-          </button>
-          <button type="button" class="wf-filter-btn">
-            <span class="wf-swatch wf-swatch--thick wf-swatch--font"></span>font
-          </button>
-          <button type="button" class="wf-filter-btn">
-            <span class="wf-swatch wf-swatch--thick wf-swatch--other"></span
-            >other
-          </button>
+          <button type="button" class="wf-filter-btn active">
+          all
+        </button>
+        <button type="button" class="wf-filter-btn">
+          <span
+              class="wf-swatch wf-swatch--thick wf-swatch--html"
+            ></span>HTML
+        </button>
+        <button type="button" class="wf-filter-btn">
+          <span
+              class="wf-swatch wf-swatch--thick wf-swatch--js"
+            ></span>JS
+        </button>
+        <button type="button" class="wf-filter-btn">
+          <span
+              class="wf-swatch wf-swatch--thick wf-swatch--css"
+            ></span>CSS
+        </button>
+        <button type="button" class="wf-filter-btn">
+          <span
+              class="wf-swatch wf-swatch--thick wf-swatch--image"
+            ></span>image
+        </button>
+        <button type="button" class="wf-filter-btn">
+          <span
+              class="wf-swatch wf-swatch--thick wf-swatch--font"
+            ></span>font
+        </button>
+        <button type="button" class="wf-filter-btn">
+          <span
+              class="wf-swatch wf-swatch--thick wf-swatch--other"
+            ></span>other
+        </button>
         </div>
         <div
           class="wf-legend-group"
@@ -93,29 +129,33 @@
             <span class="wf-swatch wf-swatch--thin wf-swatch--blocked"></span
             >Blocked
           </button>
-          <button type="button" class="wf-filter-btn" data-phase="dns">
-            <span class="wf-swatch wf-swatch--thin wf-swatch--dns"></span>DNS
-            Lookup
+        <button type="button" class="wf-filter-btn" data-phase="dns">
+            <span class="wf-swatch wf-swatch--thin wf-swatch--dns"></span
+            >DNS Lookup
           </button>
-          <button type="button" class="wf-filter-btn" data-phase="connect">
+        <button type="button" class="wf-filter-btn" data-phase="connect">
             <span class="wf-swatch wf-swatch--thin wf-swatch--connect"></span
             >TCP Connect
           </button>
-          <button type="button" class="wf-filter-btn" data-phase="ssl">
-            <span class="wf-swatch wf-swatch--thin wf-swatch--ssl"></span>TLS
-            Handshake
+        <button type="button" class="wf-filter-btn" data-phase="ssl">
+            <span class="wf-swatch wf-swatch--thin wf-swatch--ssl"></span
+            >TLS Handshake
           </button>
         </div>
-        <div class="wf-legend-group" role="group" aria-label="Toggle metrics">
-          <button
+        <div
+              class="wf-legend-group"
+              role="group"
+              aria-label="Toggle metrics"
+            >
+              <button
             type="button"
             class="wf-filter-btn active"
             data-event="ev-dcl"
           >
-            <span class="wf-swatch wf-swatch--thin wf-swatch--ev-dcl"></span>DOM
-            Content Loaded
+            <span class="wf-swatch wf-swatch--thin wf-swatch--ev-dcl"></span
+            >DOM Content Loaded
           </button>
-          <button
+        <button
             type="button"
             class="wf-filter-btn active"
             data-event="ev-load"
@@ -123,7 +163,7 @@
             <span class="wf-swatch wf-swatch--thin wf-swatch--ev-load"></span
             >Page Load
           </button>
-          <button
+        <button
             type="button"
             class="wf-filter-btn active"
             data-event="ev-lcp"
@@ -131,889 +171,921 @@
             <span class="wf-swatch wf-swatch--thin wf-swatch--ev-lcp"></span
             >Largest Contentful Paint
           </button>
-        </div>
+            </div>
       </div>
 
-      <div class="wf-list-wrap">
-        <div class="wf-col-headers" aria-hidden="true">
-          <div class="wf-col-header wf-col-header--idx">#</div>
-          <div class="wf-col-header wf-col-header--url">URL</div>
-          <div class="wf-col-header wf-col-header--info">Method</div>
-          <div class="wf-col-header wf-col-header--info">Protocol</div>
-          <div class="wf-col-header wf-col-header--info">Status</div>
-          <div class="wf-col-header wf-col-header--info">Type</div>
-          <div class="wf-col-header wf-col-header--info wf-col-header--size">
-            Size
-          </div>
-          <div class="wf-col-header wf-col-header--info wf-col-header--dur">
-            Duration
-          </div>
-          <div class="wf-col-header wf-col-header--timeline">
-            <div class="wf-ruler" aria-hidden="true">
-              <span class="wf-tick" style="left: 24.6609%">0.2s</span>
-              <span class="wf-tick" style="left: 49.3218%">0.4s</span>
-              <span class="wf-tick" style="left: 73.9827%">0.6s</span>
-              <span class="wf-tick" style="left: 98.6436%">0.8s</span>
+          <div class="wf-list-wrap">
+            <div class="wf-col-headers" aria-hidden="true">
+              <div class="wf-col-header wf-col-header--idx">#</div>
+              <div class="wf-col-header wf-col-header--url">URL</div>
+              <div class="wf-col-header wf-col-header--info">Method</div>
+              <div class="wf-col-header wf-col-header--info">Protocol</div>
+              <div class="wf-col-header wf-col-header--info">Status</div>
+              <div class="wf-col-header wf-col-header--info">Type</div>
+              <div class="wf-col-header wf-col-header--info wf-col-header--size">
+                Size
+              </div>
+              <div class="wf-col-header wf-col-header--info wf-col-header--dur">
+                Duration
+              </div>
+              <div class="wf-col-header wf-col-header--timeline">
+                <div class="wf-ruler" aria-hidden="true"><span
+            class="wf-tick"
+            style="left:24.6609%"
+            >0.2s</span
+          >
+          <span
+            class="wf-tick"
+            style="left:49.3218%"
+            >0.4s</span
+          >
+          <span
+            class="wf-tick"
+            style="left:73.9827%"
+            >0.6s</span
+          >
+          <span
+            class="wf-tick"
+            style="left:98.6436%"
+            >0.8s</span
+          ></div>
+                <div class="wf-grid-overlay" aria-hidden="true">
+                  <div
+              class="wf-grid-line"
+              style="left:24.6609%"
+            ></div>
+          <div
+              class="wf-grid-line"
+              style="left:49.3218%"
+            ></div>
+          <div
+              class="wf-grid-line"
+              style="left:73.9827%"
+            ></div>
+          <div
+              class="wf-grid-line"
+              style="left:98.6436%"
+            ></div>
+                </div>
+                <div class="wf-events-overlay" aria-hidden="true">
+                  <div
+            class="wf-event-line wf-event--dcl"
+            data-ms="340"
+            data-label="DCL 340 ms"
+            data-name="DCL"
+            style="left:41.9236%"
+          ></div>
+          <div
+            class="wf-event-line wf-event--load"
+            data-ms="620"
+            data-label="Load 620 ms"
+            data-name="Load"
+            style="left:76.4488%"
+          ></div>
+          <div
+            class="wf-event-line wf-event--lcp"
+            data-ms="480"
+            data-label="LCP 480 ms"
+            data-name="LCP"
+            style="left:59.1862%"
+          ></div>
+                </div>
+              </div>
             </div>
-            <div class="wf-grid-overlay" aria-hidden="true">
-              <div class="wf-grid-line" style="left: 24.6609%"></div>
-              <div class="wf-grid-line" style="left: 49.3218%"></div>
-              <div class="wf-grid-line" style="left: 73.9827%"></div>
-              <div class="wf-grid-line" style="left: 98.6436%"></div>
-            </div>
-            <div class="wf-events-overlay" aria-hidden="true">
-              <div
-                class="wf-event-line wf-event--dcl"
-                data-ms="340"
-                data-label="DCL 340 ms"
-                data-name="DCL"
-                style="left: 41.9236%"
-              ></div>
-              <div
-                class="wf-event-line wf-event--load"
-                data-ms="620"
-                data-label="Load 620 ms"
-                data-name="Load"
-                style="left: 76.4488%"
-              ></div>
-              <div
-                class="wf-event-line wf-event--lcp"
-                data-ms="480"
-                data-label="LCP 480 ms"
-                data-name="LCP"
-                style="left: 59.1862%"
-              ></div>
-            </div>
-          </div>
-        </div>
-        <ol class="wf-list" aria-label="Network requests">
-          <li
-            class="wf-row wf-row--rh26"
-            data-index="0"
-            data-started="2024-01-15T10:00:00.000Z"
-            data-time="164"
-            data-blocked="12"
-            data-dns="0"
-            data-connect="0"
-            data-ssl="0"
-            data-send="6"
-            data-wait="28"
-            data-receive="118"
-            data-body-size="18200"
-            data-transfer-size="13104"
-          >
-            <span class="wf-cell wf-cell--idx">1</span>
-            <span class="wf-cell wf-cell--url" title="https://example.com/"
-              ><span class="wf-url-domain">example.com</span></span
-            >
-            <span class="wf-cell wf-cell--info">GET</span>
-            <span class="wf-cell wf-cell--info">h2</span>
-            <span class="wf-cell wf-cell--info wf-cell--stat s2xx">200</span>
-            <span class="wf-cell wf-cell--info">html</span>
-            <span class="wf-cell wf-cell--info wf-cell--size">12.8 KB</span>
-            <span class="wf-cell wf-cell--info wf-cell--dur">164 ms</span>
-            <span
-              class="wf-cell wf-cell--timeline"
-              style="--wf-bar-end: 20.2219%"
-            >
-              <div class="wf-bar-wrap">
-                <div
-                  class="wb wb--blocked wb--phase"
-                  title="Blocked: 12 ms"
-                  style="left: 0%; width: 1.4797%"
-                ></div>
-                <div
-                  class="wb wb--html-light"
-                  title="Send+Wait: 34 ms"
-                  style="left: 1.4797%; width: 4.1924%"
-                ></div>
-                <div
-                  class="wb wb--html-dark"
-                  title="Receive: 118 ms"
-                  style="left: 5.672%; width: 14.5499%"
-                ></div>
-                <span class="wf-bar-dur">164 ms</span>
-              </div>
-            </span>
-          </li>
-          <li
-            class="wf-row wf-row--rh26"
-            data-index="1"
-            data-started="2024-01-15T10:00:00.148Z"
-            data-time="53"
-            data-blocked="2"
-            data-dns="0"
-            data-connect="0"
-            data-ssl="0"
-            data-send="1"
-            data-wait="18"
-            data-receive="32"
-            data-body-size="4800"
-            data-transfer-size="3456"
-          >
-            <span class="wf-cell wf-cell--idx">2</span>
-            <span
-              class="wf-cell wf-cell--url"
-              title="https://example.com/assets/main.css"
-              ><span class="wf-url-domain">example.com</span
-              ><span class="wf-url-path">/assets/main.css</span></span
-            >
-            <span class="wf-cell wf-cell--info">GET</span>
-            <span class="wf-cell wf-cell--info">h2</span>
-            <span class="wf-cell wf-cell--info wf-cell--stat s2xx">200</span>
-            <span class="wf-cell wf-cell--info">css</span>
-            <span class="wf-cell wf-cell--info wf-cell--size">3.4 KB</span>
-            <span class="wf-cell wf-cell--info wf-cell--dur">53 ms</span>
-            <span
-              class="wf-cell wf-cell--timeline"
-              style="--wf-bar-end: 24.7842%"
-            >
-              <div class="wf-bar-wrap">
-                <div
-                  class="wb wb--blocked wb--phase"
-                  title="Blocked: 2 ms"
-                  style="left: 18.2491%; width: 0.2466%"
-                ></div>
-                <div
-                  class="wb wb--css-light"
-                  title="Send+Wait: 19 ms"
-                  style="left: 18.4957%; width: 2.3428%"
-                ></div>
-                <div
-                  class="wb wb--css-dark"
-                  title="Receive: 32 ms"
-                  style="left: 20.8385%; width: 3.9457%"
-                ></div>
-                <span class="wf-bar-dur">53 ms</span>
-              </div>
-            </span>
-          </li>
-          <li
-            class="wf-row wf-row--rh26"
-            data-index="2"
-            data-started="2024-01-15T10:00:00.150Z"
-            data-time="80"
-            data-blocked="2"
-            data-dns="0"
-            data-connect="0"
-            data-ssl="0"
-            data-send="1"
-            data-wait="22"
-            data-receive="55"
-            data-body-size="12400"
-            data-transfer-size="8928"
-          >
-            <span class="wf-cell wf-cell--idx">3</span>
-            <span
-              class="wf-cell wf-cell--url"
-              title="https://example.com/assets/runtime.js"
-              ><span class="wf-url-domain">example.com</span
-              ><span class="wf-url-path">/assets/runtime.js</span></span
-            >
-            <span class="wf-cell wf-cell--info">GET</span>
-            <span class="wf-cell wf-cell--info">h2</span>
-            <span class="wf-cell wf-cell--info wf-cell--stat s2xx">200</span>
-            <span class="wf-cell wf-cell--info">js</span>
-            <span class="wf-cell wf-cell--info wf-cell--size">8.7 KB</span>
-            <span class="wf-cell wf-cell--info wf-cell--dur">80 ms</span>
-            <span
-              class="wf-cell wf-cell--timeline"
-              style="--wf-bar-end: 28.36%"
-            >
-              <div class="wf-bar-wrap">
-                <div
-                  class="wb wb--blocked wb--phase"
-                  title="Blocked: 2 ms"
-                  style="left: 18.4957%; width: 0.2466%"
-                ></div>
-                <div
-                  class="wb wb--js-light"
-                  title="Send+Wait: 23 ms"
-                  style="left: 18.7423%; width: 2.836%"
-                ></div>
-                <div
-                  class="wb wb--js-dark"
-                  title="Receive: 55 ms"
-                  style="left: 21.5783%; width: 6.7818%"
-                ></div>
-                <span class="wf-bar-dur">80 ms</span>
-              </div>
-            </span>
-          </li>
-          <li
-            class="wf-row wf-row--rh26"
-            data-index="3"
-            data-started="2024-01-15T10:00:00.152Z"
-            data-time="208"
-            data-blocked="2"
-            data-dns="0"
-            data-connect="0"
-            data-ssl="0"
-            data-send="1"
-            data-wait="25"
-            data-receive="180"
-            data-body-size="68000"
-            data-transfer-size="48960"
-          >
-            <span class="wf-cell wf-cell--idx">4</span>
-            <span
-              class="wf-cell wf-cell--url"
-              title="https://example.com/assets/app.js"
-              ><span class="wf-url-domain">example.com</span
-              ><span class="wf-url-path">/assets/app.js</span></span
-            >
-            <span class="wf-cell wf-cell--info">GET</span>
-            <span class="wf-cell wf-cell--info">h2</span>
-            <span class="wf-cell wf-cell--info wf-cell--stat s2xx">200</span>
-            <span class="wf-cell wf-cell--info">js</span>
-            <span class="wf-cell wf-cell--info wf-cell--size">47.8 KB</span>
-            <span class="wf-cell wf-cell--info wf-cell--dur">208 ms</span>
-            <span
-              class="wf-cell wf-cell--timeline"
-              style="--wf-bar-end: 44.3896%"
-            >
-              <div class="wf-bar-wrap">
-                <div
-                  class="wb wb--blocked wb--phase"
-                  title="Blocked: 2 ms"
-                  style="left: 18.7423%; width: 0.2466%"
-                ></div>
-                <div
-                  class="wb wb--js-light"
-                  title="Send+Wait: 26 ms"
-                  style="left: 18.9889%; width: 3.2059%"
-                ></div>
-                <div
-                  class="wb wb--js-dark"
-                  title="Receive: 180 ms"
-                  style="left: 22.1948%; width: 22.1948%"
-                ></div>
-                <span class="wf-bar-dur">208 ms</span>
-              </div>
-            </span>
-          </li>
-          <li
-            class="wf-row wf-row--rh26"
-            data-index="4"
-            data-started="2024-01-15T10:00:00.155Z"
-            data-time="159"
-            data-blocked="0"
-            data-dns="12"
-            data-connect="28"
-            data-ssl="18"
-            data-send="1"
-            data-wait="38"
-            data-receive="62"
-            data-body-size="22000"
-            data-transfer-size="15840"
-          >
-            <span class="wf-cell wf-cell--idx">5</span>
-            <span
-              class="wf-cell wf-cell--url"
-              title="https://fonts.example.com/inter-400.woff2"
-              ><span class="wf-url-domain">fonts.example.com</span
-              ><span class="wf-url-path">/inter-400.woff2</span></span
-            >
-            <span class="wf-cell wf-cell--info">GET</span>
-            <span class="wf-cell wf-cell--info">h2</span>
-            <span class="wf-cell wf-cell--info wf-cell--stat s2xx">200</span>
-            <span class="wf-cell wf-cell--info">font</span>
-            <span class="wf-cell wf-cell--info wf-cell--size">15.5 KB</span>
-            <span class="wf-cell wf-cell--info wf-cell--dur">159 ms</span>
-            <span
-              class="wf-cell wf-cell--timeline"
-              style="--wf-bar-end: 38.7176%"
-            >
-              <div class="wf-bar-wrap">
-                <div
-                  class="wb wb--dns wb--phase"
-                  title="DNS Lookup: 12 ms"
-                  style="left: 19.1122%; width: 1.4797%"
-                ></div>
-                <div
-                  class="wb wb--connect wb--phase"
-                  title="TCP Connect: 28 ms"
-                  style="left: 20.5919%; width: 3.4525%"
-                ></div>
-                <div
-                  class="wb wb--ssl wb--phase"
-                  title="TLS Handshake: 18 ms"
-                  style="left: 24.0444%; width: 2.2195%"
-                ></div>
-                <div
-                  class="wb wb--font-light"
-                  title="Send+Wait: 39 ms"
-                  style="left: 26.2639%; width: 4.8089%"
-                ></div>
-                <div
-                  class="wb wb--font-dark"
-                  title="Receive: 62 ms"
-                  style="left: 31.0727%; width: 7.6449%"
-                ></div>
-                <span class="wf-bar-dur">159 ms</span>
-              </div>
-            </span>
-          </li>
-          <li
-            class="wf-row wf-row--rh26"
-            data-index="5"
-            data-started="2024-01-15T10:00:00.158Z"
-            data-time="157"
-            data-blocked="0"
-            data-dns="12"
-            data-connect="28"
-            data-ssl="18"
-            data-send="1"
-            data-wait="40"
-            data-receive="58"
-            data-body-size="19500"
-            data-transfer-size="14040"
-          >
-            <span class="wf-cell wf-cell--idx">6</span>
-            <span
-              class="wf-cell wf-cell--url"
-              title="https://fonts.example.com/inter-600.woff2"
-              ><span class="wf-url-domain">fonts.example.com</span
-              ><span class="wf-url-path">/inter-600.woff2</span></span
-            >
-            <span class="wf-cell wf-cell--info">GET</span>
-            <span class="wf-cell wf-cell--info">h2</span>
-            <span class="wf-cell wf-cell--info wf-cell--stat s2xx">200</span>
-            <span class="wf-cell wf-cell--info">font</span>
-            <span class="wf-cell wf-cell--info wf-cell--size">13.7 KB</span>
-            <span class="wf-cell wf-cell--info wf-cell--dur">157 ms</span>
-            <span
-              class="wf-cell wf-cell--timeline"
-              style="--wf-bar-end: 38.8409%"
-            >
-              <div class="wf-bar-wrap">
-                <div
-                  class="wb wb--dns wb--phase"
-                  title="DNS Lookup: 12 ms"
-                  style="left: 19.4821%; width: 1.4797%"
-                ></div>
-                <div
-                  class="wb wb--connect wb--phase"
-                  title="TCP Connect: 28 ms"
-                  style="left: 20.9618%; width: 3.4525%"
-                ></div>
-                <div
-                  class="wb wb--ssl wb--phase"
-                  title="TLS Handshake: 18 ms"
-                  style="left: 24.4143%; width: 2.2195%"
-                ></div>
-                <div
-                  class="wb wb--font-light"
-                  title="Send+Wait: 41 ms"
-                  style="left: 26.6338%; width: 5.0555%"
-                ></div>
-                <div
-                  class="wb wb--font-dark"
-                  title="Receive: 58 ms"
-                  style="left: 31.6893%; width: 7.1517%"
-                ></div>
-                <span class="wf-bar-dur">157 ms</span>
-              </div>
-            </span>
-          </li>
-          <li
-            class="wf-row wf-row--rh26"
-            data-index="6"
-            data-started="2024-01-15T10:00:00.200Z"
-            data-time="410"
-            data-blocked="0"
-            data-dns="8"
-            data-connect="22"
-            data-ssl="14"
-            data-send="1"
-            data-wait="55"
-            data-receive="310"
-            data-body-size="95000"
-            data-transfer-size="68400"
-          >
-            <span class="wf-cell wf-cell--idx">7</span>
-            <span
-              class="wf-cell wf-cell--url"
-              title="https://cdn.example.com/hero.webp"
-              ><span class="wf-url-domain">cdn.example.com</span
-              ><span class="wf-url-path">/hero.webp</span></span
-            >
-            <span class="wf-cell wf-cell--info">GET</span>
-            <span class="wf-cell wf-cell--info">h2</span>
-            <span class="wf-cell wf-cell--info wf-cell--stat s2xx">200</span>
-            <span class="wf-cell wf-cell--info">image</span>
-            <span class="wf-cell wf-cell--info wf-cell--size">66.8 KB</span>
-            <span class="wf-cell wf-cell--info wf-cell--dur">410 ms</span>
-            <span
-              class="wf-cell wf-cell--timeline"
-              style="--wf-bar-end: 75.2158%"
-            >
-              <div class="wf-bar-wrap">
-                <div
-                  class="wb wb--dns wb--phase"
-                  title="DNS Lookup: 8 ms"
-                  style="left: 24.6609%; width: 0.9864%"
-                ></div>
-                <div
-                  class="wb wb--connect wb--phase"
-                  title="TCP Connect: 22 ms"
-                  style="left: 25.6473%; width: 2.7127%"
-                ></div>
-                <div
-                  class="wb wb--ssl wb--phase"
-                  title="TLS Handshake: 14 ms"
-                  style="left: 28.36%; width: 1.7263%"
-                ></div>
-                <div
-                  class="wb wb--image-light"
-                  title="Send+Wait: 56 ms"
-                  style="left: 30.0863%; width: 6.9051%"
-                ></div>
-                <div
-                  class="wb wb--image-dark"
-                  title="Receive: 310 ms"
-                  style="left: 36.9914%; width: 38.2244%"
-                ></div>
-                <span class="wf-bar-dur">410 ms</span>
-              </div>
-            </span>
-          </li>
-          <li
-            class="wf-row wf-row--rh26"
-            data-index="7"
-            data-started="2024-01-15T10:00:00.205Z"
-            data-time="31"
-            data-blocked="0"
-            data-dns="0"
-            data-connect="0"
-            data-ssl="0"
-            data-send="1"
-            data-wait="12"
-            data-receive="18"
-            data-body-size="2100"
-            data-transfer-size="1512"
-          >
-            <span class="wf-cell wf-cell--idx">8</span>
-            <span
-              class="wf-cell wf-cell--url"
-              title="https://cdn.example.com/logo.svg"
-              ><span class="wf-url-domain">cdn.example.com</span
-              ><span class="wf-url-path">/logo.svg</span></span
-            >
-            <span class="wf-cell wf-cell--info">GET</span>
-            <span class="wf-cell wf-cell--info">h2</span>
-            <span class="wf-cell wf-cell--info wf-cell--stat s2xx">200</span>
-            <span class="wf-cell wf-cell--info">image</span>
-            <span class="wf-cell wf-cell--info wf-cell--size">1.5 KB</span>
-            <span class="wf-cell wf-cell--info wf-cell--dur">31 ms</span>
-            <span
-              class="wf-cell wf-cell--timeline"
-              style="--wf-bar-end: 29.0999%"
-            >
-              <div class="wf-bar-wrap">
-                <div
-                  class="wb wb--image-light"
-                  title="Send+Wait: 13 ms"
-                  style="left: 25.2774%; width: 1.603%"
-                ></div>
-                <div
-                  class="wb wb--image-dark"
-                  title="Receive: 18 ms"
-                  style="left: 26.8804%; width: 2.2195%"
-                ></div>
-                <span class="wf-bar-dur">31 ms</span>
-              </div>
-            </span>
-          </li>
-          <li
-            class="wf-row wf-row--rh26 row--blocking"
-            data-index="8"
-            data-started="2024-01-15T10:00:00.360Z"
-            data-time="299"
-            data-blocked="130"
-            data-dns="18"
-            data-connect="38"
-            data-ssl="22"
-            data-send="1"
-            data-wait="62"
-            data-receive="28"
-            data-body-size="5200"
-            data-transfer-size="3744"
-          >
-            <span class="wf-cell wf-cell--idx">9</span>
-            <span
-              class="wf-cell wf-cell--url"
-              title="https://analytics.example.com/pixel.js"
-              ><span class="wf-url-domain">analytics.example.com</span
-              ><span class="wf-url-path">/pixel.js</span></span
-            >
-            <span class="wf-cell wf-cell--info">GET</span>
-            <span class="wf-cell wf-cell--info">h2</span>
-            <span class="wf-cell wf-cell--info wf-cell--stat s2xx">200</span>
-            <span class="wf-cell wf-cell--info">js</span>
-            <span class="wf-cell wf-cell--info wf-cell--size">3.7 KB</span>
-            <span class="wf-cell wf-cell--info wf-cell--dur">299 ms</span>
-            <span
-              class="wf-cell wf-cell--timeline"
-              style="--wf-bar-end: 81.2577%"
-            >
-              <div class="wf-bar-wrap">
-                <div
-                  class="wb wb--blocked wb--phase"
-                  title="Blocked: 130 ms"
-                  style="left: 44.3896%; width: 16.0296%"
-                ></div>
-                <div
-                  class="wb wb--dns wb--phase"
-                  title="DNS Lookup: 18 ms"
-                  style="left: 60.4192%; width: 2.2195%"
-                ></div>
-                <div
-                  class="wb wb--connect wb--phase"
-                  title="TCP Connect: 38 ms"
-                  style="left: 62.6387%; width: 4.6856%"
-                ></div>
-                <div
-                  class="wb wb--ssl wb--phase"
-                  title="TLS Handshake: 22 ms"
-                  style="left: 67.3243%; width: 2.7127%"
-                ></div>
-                <div
-                  class="wb wb--js-light"
-                  title="Send+Wait: 63 ms"
-                  style="left: 70.037%; width: 7.7682%"
-                ></div>
-                <div
-                  class="wb wb--js-dark"
-                  title="Receive: 28 ms"
-                  style="left: 77.8052%; width: 3.4525%"
-                ></div>
-                <span class="wf-bar-dur">299 ms</span>
-              </div>
-            </span>
-          </li>
-          <li
-            class="wf-row wf-row--rh26 row--blocking"
-            data-index="9"
-            data-started="2024-01-15T10:00:00.362Z"
-            data-time="449"
-            data-blocked="125"
-            data-dns="22"
-            data-connect="42"
-            data-ssl="26"
-            data-send="1"
-            data-wait="88"
-            data-receive="145"
-            data-body-size="38000"
-            data-transfer-size="27360"
-          >
-            <span class="wf-cell wf-cell--idx">10</span>
-            <span
-              class="wf-cell wf-cell--url"
-              title="https://cdn.thirdparty.com/widget.js"
-              ><span class="wf-url-domain">cdn.thirdparty.com</span
-              ><span class="wf-url-path">/widget.js</span></span
-            >
-            <span class="wf-cell wf-cell--info">GET</span>
-            <span class="wf-cell wf-cell--info">h2</span>
-            <span class="wf-cell wf-cell--info wf-cell--stat s2xx">200</span>
-            <span class="wf-cell wf-cell--info">js</span>
-            <span class="wf-cell wf-cell--info wf-cell--size">26.7 KB</span>
-            <span class="wf-cell wf-cell--info wf-cell--dur">449 ms</span>
-            <span class="wf-cell wf-cell--timeline" style="--wf-bar-end: 100%">
-              <div class="wf-bar-wrap">
-                <div
-                  class="wb wb--blocked wb--phase"
-                  title="Blocked: 125 ms"
-                  style="left: 44.6363%; width: 15.4131%"
-                ></div>
-                <div
-                  class="wb wb--dns wb--phase"
-                  title="DNS Lookup: 22 ms"
-                  style="left: 60.0493%; width: 2.7127%"
-                ></div>
-                <div
-                  class="wb wb--connect wb--phase"
-                  title="TCP Connect: 42 ms"
-                  style="left: 62.762%; width: 5.1788%"
-                ></div>
-                <div
-                  class="wb wb--ssl wb--phase"
-                  title="TLS Handshake: 26 ms"
-                  style="left: 67.9408%; width: 3.2059%"
-                ></div>
-                <div
-                  class="wb wb--js-light"
-                  title="Send+Wait: 89 ms"
-                  style="left: 71.1467%; width: 10.9741%"
-                ></div>
-                <div
-                  class="wb wb--js-dark"
-                  title="Receive: 145 ms"
-                  style="left: 82.1208%; width: 17.8792%"
-                ></div>
-                <span class="wf-bar-dur">449 ms</span>
-              </div>
-            </span>
-          </li>
-          <li
-            class="wf-row wf-row--rh26"
-            data-index="10"
-            data-started="2024-01-15T10:00:00.390Z"
-            data-time="114"
-            data-blocked="0"
-            data-dns="0"
-            data-connect="0"
-            data-ssl="0"
-            data-send="1"
-            data-wait="18"
-            data-receive="95"
-            data-body-size="28000"
-            data-transfer-size="20160"
-          >
-            <span class="wf-cell wf-cell--idx">11</span>
-            <span
-              class="wf-cell wf-cell--url"
-              title="https://cdn.example.com/thumbnail-1.webp"
-              ><span class="wf-url-domain">cdn.example.com</span
-              ><span class="wf-url-path">/thumbnail-1.webp</span></span
-            >
-            <span class="wf-cell wf-cell--info">GET</span>
-            <span class="wf-cell wf-cell--info">h2</span>
-            <span class="wf-cell wf-cell--info wf-cell--stat s2xx">200</span>
-            <span class="wf-cell wf-cell--info">image</span>
-            <span class="wf-cell wf-cell--info wf-cell--size">19.7 KB</span>
-            <span class="wf-cell wf-cell--info wf-cell--dur">114 ms</span>
-            <span
-              class="wf-cell wf-cell--timeline"
-              style="--wf-bar-end: 62.1455%"
-            >
-              <div class="wf-bar-wrap">
-                <div
-                  class="wb wb--image-light"
-                  title="Send+Wait: 19 ms"
-                  style="left: 48.0888%; width: 2.3428%"
-                ></div>
-                <div
-                  class="wb wb--image-dark"
-                  title="Receive: 95 ms"
-                  style="left: 50.4316%; width: 11.7139%"
-                ></div>
-                <span class="wf-bar-dur">114 ms</span>
-              </div>
-            </span>
-          </li>
-          <li
-            class="wf-row wf-row--rh26"
-            data-index="11"
-            data-started="2024-01-15T10:00:00.392Z"
-            data-time="123"
-            data-blocked="0"
-            data-dns="0"
-            data-connect="0"
-            data-ssl="0"
-            data-send="1"
-            data-wait="20"
-            data-receive="102"
-            data-body-size="31000"
-            data-transfer-size="22320"
-          >
-            <span class="wf-cell wf-cell--idx">12</span>
-            <span
-              class="wf-cell wf-cell--url"
-              title="https://cdn.example.com/thumbnail-2.webp"
-              ><span class="wf-url-domain">cdn.example.com</span
-              ><span class="wf-url-path">/thumbnail-2.webp</span></span
-            >
-            <span class="wf-cell wf-cell--info">GET</span>
-            <span class="wf-cell wf-cell--info">h2</span>
-            <span class="wf-cell wf-cell--info wf-cell--stat s2xx">200</span>
-            <span class="wf-cell wf-cell--info">image</span>
-            <span class="wf-cell wf-cell--info wf-cell--size">21.8 KB</span>
-            <span class="wf-cell wf-cell--info wf-cell--dur">123 ms</span>
-            <span
-              class="wf-cell wf-cell--timeline"
-              style="--wf-bar-end: 63.5018%"
-            >
-              <div class="wf-bar-wrap">
-                <div
-                  class="wb wb--image-light"
-                  title="Send+Wait: 21 ms"
-                  style="left: 48.3354%; width: 2.5894%"
-                ></div>
-                <div
-                  class="wb wb--image-dark"
-                  title="Receive: 102 ms"
-                  style="left: 50.9248%; width: 12.5771%"
-                ></div>
-                <span class="wf-bar-dur">123 ms</span>
-              </div>
-            </span>
-          </li>
-          <li
-            class="wf-row wf-row--rh26"
-            data-index="12"
-            data-started="2024-01-15T10:00:00.395Z"
-            data-time="111"
-            data-blocked="0"
-            data-dns="0"
-            data-connect="0"
-            data-ssl="0"
-            data-send="1"
-            data-wait="22"
-            data-receive="88"
-            data-body-size="24500"
-            data-transfer-size="17640"
-          >
-            <span class="wf-cell wf-cell--idx">13</span>
-            <span
-              class="wf-cell wf-cell--url"
-              title="https://cdn.example.com/thumbnail-3.webp"
-              ><span class="wf-url-domain">cdn.example.com</span
-              ><span class="wf-url-path">/thumbnail-3.webp</span></span
-            >
-            <span class="wf-cell wf-cell--info">GET</span>
-            <span class="wf-cell wf-cell--info">h2</span>
-            <span class="wf-cell wf-cell--info wf-cell--stat s2xx">200</span>
-            <span class="wf-cell wf-cell--info">image</span>
-            <span class="wf-cell wf-cell--info wf-cell--size">17.2 KB</span>
-            <span class="wf-cell wf-cell--info wf-cell--dur">111 ms</span>
-            <span
-              class="wf-cell wf-cell--timeline"
-              style="--wf-bar-end: 62.3921%"
-            >
-              <div class="wf-bar-wrap">
-                <div
-                  class="wb wb--image-light"
-                  title="Send+Wait: 23 ms"
-                  style="left: 48.7053%; width: 2.836%"
-                ></div>
-                <div
-                  class="wb wb--image-dark"
-                  title="Receive: 88 ms"
-                  style="left: 51.5413%; width: 10.8508%"
-                ></div>
-                <span class="wf-bar-dur">111 ms</span>
-              </div>
-            </span>
-          </li>
-          <li
-            class="wf-row wf-row--rh26"
-            data-index="13"
-            data-started="2024-01-15T10:00:00.420Z"
-            data-time="108"
-            data-blocked="0"
-            data-dns="10"
-            data-connect="24"
-            data-ssl="16"
-            data-send="1"
-            data-wait="45"
-            data-receive="12"
-            data-body-size="1800"
-            data-transfer-size="1296"
-          >
-            <span class="wf-cell wf-cell--idx">14</span>
-            <span
-              class="wf-cell wf-cell--url"
-              title="https://api.example.com/v1/config"
-              ><span class="wf-url-domain">api.example.com</span
-              ><span class="wf-url-path">/v1/config</span></span
-            >
-            <span class="wf-cell wf-cell--info">GET</span>
-            <span class="wf-cell wf-cell--info">h2</span>
-            <span class="wf-cell wf-cell--info wf-cell--stat s2xx">200</span>
-            <span class="wf-cell wf-cell--info">other</span>
-            <span class="wf-cell wf-cell--info wf-cell--size">1.3 KB</span>
-            <span class="wf-cell wf-cell--info wf-cell--dur">108 ms</span>
-            <span
-              class="wf-cell wf-cell--timeline"
-              style="--wf-bar-end: 65.1048%"
-            >
-              <div class="wf-bar-wrap">
-                <div
-                  class="wb wb--dns wb--phase"
-                  title="DNS Lookup: 10 ms"
-                  style="left: 51.7879%; width: 1.233%"
-                ></div>
-                <div
-                  class="wb wb--connect wb--phase"
-                  title="TCP Connect: 24 ms"
-                  style="left: 53.021%; width: 2.9593%"
-                ></div>
-                <div
-                  class="wb wb--ssl wb--phase"
-                  title="TLS Handshake: 16 ms"
-                  style="left: 55.9803%; width: 1.9729%"
-                ></div>
-                <div
-                  class="wb wb--other-light"
-                  title="Send+Wait: 46 ms"
-                  style="left: 57.9531%; width: 5.672%"
-                ></div>
-                <div
-                  class="wb wb--other-dark"
-                  title="Receive: 12 ms"
-                  style="left: 63.6252%; width: 1.4797%"
-                ></div>
-                <span class="wf-bar-dur">108 ms</span>
-              </div>
-            </span>
-          </li>
-          <li
-            class="wf-row wf-row--rh26"
-            data-index="14"
-            data-started="2024-01-15T10:00:00.440Z"
-            data-time="182"
-            data-blocked="0"
-            data-dns="0"
-            data-connect="0"
-            data-ssl="0"
-            data-send="2"
-            data-wait="142"
-            data-receive="38"
-            data-body-size="6400"
-            data-transfer-size="4608"
-          >
-            <span class="wf-cell wf-cell--idx">15</span>
-            <span
-              class="wf-cell wf-cell--url"
-              title="https://api.example.com/v1/recommendations"
-              ><span class="wf-url-domain">api.example.com</span
-              ><span class="wf-url-path">/v1/recommendations</span></span
-            >
-            <span class="wf-cell wf-cell--info">GET</span>
-            <span class="wf-cell wf-cell--info">h2</span>
-            <span class="wf-cell wf-cell--info wf-cell--stat s2xx">200</span>
-            <span class="wf-cell wf-cell--info">other</span>
-            <span class="wf-cell wf-cell--info wf-cell--size">4.5 KB</span>
-            <span class="wf-cell wf-cell--info wf-cell--dur">182 ms</span>
-            <span
-              class="wf-cell wf-cell--timeline"
-              style="--wf-bar-end: 76.6954%"
-            >
-              <div class="wf-bar-wrap">
-                <div
-                  class="wb wb--other-light"
-                  title="Send+Wait: 144 ms"
-                  style="left: 54.254%; width: 17.7559%"
-                ></div>
-                <div
-                  class="wb wb--other-dark"
-                  title="Receive: 38 ms"
-                  style="left: 72.0099%; width: 4.6856%"
-                ></div>
-                <span class="wf-bar-dur">182 ms</span>
-              </div>
-            </span>
-          </li>
-        </ol>
-      </div>
+            <ol class="wf-list" aria-label="Network requests">
+              <li
+        class="wf-row wf-row--rh26"
+        data-index="0"
+        data-started="2024-01-15T10:00:00.000Z"
+        data-time="164"
+        data-blocked="12"
 
-      <p class="wf-message wf-loading" aria-live="polite" hidden>
-        Loading waterfall…
-      </p>
-      <p class="wf-message wf-message--error wf-error" hidden></p>
-      <!-- wf-demo-end -->
+        data-dns="0"
+        data-connect="0"
+        data-ssl="0"
+        data-send="6"
+        data-wait="28"
+        data-receive="118"
+        data-body-size="18200"
+         data-transfer-size="13104"
+      >
+        <span class="wf-cell wf-cell--idx">1</span>
+        <span class="wf-cell wf-cell--url" title="https://example.com/"
+          ><span class="wf-url-domain">example.com</span></span
+        >
+        <span class="wf-cell wf-cell--info">GET</span>
+        <span class="wf-cell wf-cell--info">h2</span>
+        <span class="wf-cell wf-cell--info wf-cell--stat s2xx"
+          >200</span
+        >
+        <span class="wf-cell wf-cell--info">html</span>
+        <span class="wf-cell wf-cell--info wf-cell--size">12.8 KB</span>
+        <span class="wf-cell wf-cell--info wf-cell--dur">164 ms</span>
+        <span
+        class="wf-cell wf-cell--timeline"
+        style="--wf-bar-end:20.2219%"
+      >
+        <div class="wf-bar-wrap">
+          <div
+              class="wb wb--blocked wb--phase"
+              title="Blocked: 12 ms"
+              style="left:0.0000%;width:1.4797%"
+            ></div>
+              <div
+              class="wb wb--html-light"
+              title="Send+Wait: 34 ms"
+              style="left:1.4797%;width:4.1924%"
+            ></div>
+              <div
+              class="wb wb--html-dark"
+              title="Receive: 118 ms"
+              style="left:5.6720%;width:14.5499%"
+            ></div>
+          <span class="wf-bar-dur">164 ms</span>
+        </div>
+      </span>
+      </li>
+        <li
+        class="wf-row wf-row--rh26"
+        data-index="1"
+        data-started="2024-01-15T10:00:00.148Z"
+        data-time="53"
+        data-blocked="2"
+
+        data-dns="0"
+        data-connect="0"
+        data-ssl="0"
+        data-send="1"
+        data-wait="18"
+        data-receive="32"
+        data-body-size="4800"
+         data-transfer-size="3456"
+      >
+        <span class="wf-cell wf-cell--idx">2</span>
+        <span class="wf-cell wf-cell--url" title="https://example.com/assets/main.css"
+          ><span class="wf-url-domain">example.com</span><span class="wf-url-path">/assets/main.css</span></span
+        >
+        <span class="wf-cell wf-cell--info">GET</span>
+        <span class="wf-cell wf-cell--info">h2</span>
+        <span class="wf-cell wf-cell--info wf-cell--stat s2xx"
+          >200</span
+        >
+        <span class="wf-cell wf-cell--info">css</span>
+        <span class="wf-cell wf-cell--info wf-cell--size">3.4 KB</span>
+        <span class="wf-cell wf-cell--info wf-cell--dur">53 ms</span>
+        <span
+        class="wf-cell wf-cell--timeline"
+        style="--wf-bar-end:24.7842%"
+      >
+        <div class="wf-bar-wrap">
+          <div
+              class="wb wb--blocked wb--phase"
+              title="Blocked: 2 ms"
+              style="left:18.2491%;width:0.2466%"
+            ></div>
+              <div
+              class="wb wb--css-light"
+              title="Send+Wait: 19 ms"
+              style="left:18.4957%;width:2.3428%"
+            ></div>
+              <div
+              class="wb wb--css-dark"
+              title="Receive: 32 ms"
+              style="left:20.8385%;width:3.9457%"
+            ></div>
+          <span class="wf-bar-dur">53 ms</span>
+        </div>
+      </span>
+      </li>
+        <li
+        class="wf-row wf-row--rh26"
+        data-index="2"
+        data-started="2024-01-15T10:00:00.150Z"
+        data-time="80"
+        data-blocked="2"
+
+        data-dns="0"
+        data-connect="0"
+        data-ssl="0"
+        data-send="1"
+        data-wait="22"
+        data-receive="55"
+        data-body-size="12400"
+         data-transfer-size="8928"
+      >
+        <span class="wf-cell wf-cell--idx">3</span>
+        <span class="wf-cell wf-cell--url" title="https://example.com/assets/runtime.js"
+          ><span class="wf-url-domain">example.com</span><span class="wf-url-path">/assets/runtime.js</span></span
+        >
+        <span class="wf-cell wf-cell--info">GET</span>
+        <span class="wf-cell wf-cell--info">h2</span>
+        <span class="wf-cell wf-cell--info wf-cell--stat s2xx"
+          >200</span
+        >
+        <span class="wf-cell wf-cell--info">js</span>
+        <span class="wf-cell wf-cell--info wf-cell--size">8.7 KB</span>
+        <span class="wf-cell wf-cell--info wf-cell--dur">80 ms</span>
+        <span
+        class="wf-cell wf-cell--timeline"
+        style="--wf-bar-end:28.3600%"
+      >
+        <div class="wf-bar-wrap">
+          <div
+              class="wb wb--blocked wb--phase"
+              title="Blocked: 2 ms"
+              style="left:18.4957%;width:0.2466%"
+            ></div>
+              <div
+              class="wb wb--js-light"
+              title="Send+Wait: 23 ms"
+              style="left:18.7423%;width:2.8360%"
+            ></div>
+              <div
+              class="wb wb--js-dark"
+              title="Receive: 55 ms"
+              style="left:21.5783%;width:6.7818%"
+            ></div>
+          <span class="wf-bar-dur">80 ms</span>
+        </div>
+      </span>
+      </li>
+        <li
+        class="wf-row wf-row--rh26"
+        data-index="3"
+        data-started="2024-01-15T10:00:00.152Z"
+        data-time="208"
+        data-blocked="2"
+
+        data-dns="0"
+        data-connect="0"
+        data-ssl="0"
+        data-send="1"
+        data-wait="25"
+        data-receive="180"
+        data-body-size="68000"
+         data-transfer-size="48960"
+      >
+        <span class="wf-cell wf-cell--idx">4</span>
+        <span class="wf-cell wf-cell--url" title="https://example.com/assets/app.js"
+          ><span class="wf-url-domain">example.com</span><span class="wf-url-path">/assets/app.js</span></span
+        >
+        <span class="wf-cell wf-cell--info">GET</span>
+        <span class="wf-cell wf-cell--info">h2</span>
+        <span class="wf-cell wf-cell--info wf-cell--stat s2xx"
+          >200</span
+        >
+        <span class="wf-cell wf-cell--info">js</span>
+        <span class="wf-cell wf-cell--info wf-cell--size">47.8 KB</span>
+        <span class="wf-cell wf-cell--info wf-cell--dur">208 ms</span>
+        <span
+        class="wf-cell wf-cell--timeline"
+        style="--wf-bar-end:44.3896%"
+      >
+        <div class="wf-bar-wrap">
+          <div
+              class="wb wb--blocked wb--phase"
+              title="Blocked: 2 ms"
+              style="left:18.7423%;width:0.2466%"
+            ></div>
+              <div
+              class="wb wb--js-light"
+              title="Send+Wait: 26 ms"
+              style="left:18.9889%;width:3.2059%"
+            ></div>
+              <div
+              class="wb wb--js-dark"
+              title="Receive: 180 ms"
+              style="left:22.1948%;width:22.1948%"
+            ></div>
+          <span class="wf-bar-dur">208 ms</span>
+        </div>
+      </span>
+      </li>
+        <li
+        class="wf-row wf-row--rh26"
+        data-index="4"
+        data-started="2024-01-15T10:00:00.155Z"
+        data-time="159"
+        data-blocked="0"
+
+        data-dns="12"
+        data-connect="28"
+        data-ssl="18"
+        data-send="1"
+        data-wait="38"
+        data-receive="62"
+        data-body-size="22000"
+         data-transfer-size="15840"
+      >
+        <span class="wf-cell wf-cell--idx">5</span>
+        <span class="wf-cell wf-cell--url" title="https://fonts.example.com/inter-400.woff2"
+          ><span class="wf-url-domain">fonts.example.com</span><span class="wf-url-path">/inter-400.woff2</span></span
+        >
+        <span class="wf-cell wf-cell--info">GET</span>
+        <span class="wf-cell wf-cell--info">h2</span>
+        <span class="wf-cell wf-cell--info wf-cell--stat s2xx"
+          >200</span
+        >
+        <span class="wf-cell wf-cell--info">font</span>
+        <span class="wf-cell wf-cell--info wf-cell--size">15.5 KB</span>
+        <span class="wf-cell wf-cell--info wf-cell--dur">159 ms</span>
+        <span
+        class="wf-cell wf-cell--timeline"
+        style="--wf-bar-end:38.7176%"
+      >
+        <div class="wf-bar-wrap">
+          <div
+              class="wb wb--dns wb--phase"
+              title="DNS Lookup: 12 ms"
+              style="left:19.1122%;width:1.4797%"
+            ></div>
+              <div
+              class="wb wb--connect wb--phase"
+              title="TCP Connect: 28 ms"
+              style="left:20.5919%;width:3.4525%"
+            ></div>
+              <div
+              class="wb wb--ssl wb--phase"
+              title="TLS Handshake: 18 ms"
+              style="left:24.0444%;width:2.2195%"
+            ></div>
+              <div
+              class="wb wb--font-light"
+              title="Send+Wait: 39 ms"
+              style="left:26.2639%;width:4.8089%"
+            ></div>
+              <div
+              class="wb wb--font-dark"
+              title="Receive: 62 ms"
+              style="left:31.0727%;width:7.6449%"
+            ></div>
+          <span class="wf-bar-dur">159 ms</span>
+        </div>
+      </span>
+      </li>
+        <li
+        class="wf-row wf-row--rh26"
+        data-index="5"
+        data-started="2024-01-15T10:00:00.158Z"
+        data-time="157"
+        data-blocked="0"
+
+        data-dns="12"
+        data-connect="28"
+        data-ssl="18"
+        data-send="1"
+        data-wait="40"
+        data-receive="58"
+        data-body-size="19500"
+         data-transfer-size="14040"
+      >
+        <span class="wf-cell wf-cell--idx">6</span>
+        <span class="wf-cell wf-cell--url" title="https://fonts.example.com/inter-600.woff2"
+          ><span class="wf-url-domain">fonts.example.com</span><span class="wf-url-path">/inter-600.woff2</span></span
+        >
+        <span class="wf-cell wf-cell--info">GET</span>
+        <span class="wf-cell wf-cell--info">h2</span>
+        <span class="wf-cell wf-cell--info wf-cell--stat s2xx"
+          >200</span
+        >
+        <span class="wf-cell wf-cell--info">font</span>
+        <span class="wf-cell wf-cell--info wf-cell--size">13.7 KB</span>
+        <span class="wf-cell wf-cell--info wf-cell--dur">157 ms</span>
+        <span
+        class="wf-cell wf-cell--timeline"
+        style="--wf-bar-end:38.8409%"
+      >
+        <div class="wf-bar-wrap">
+          <div
+              class="wb wb--dns wb--phase"
+              title="DNS Lookup: 12 ms"
+              style="left:19.4821%;width:1.4797%"
+            ></div>
+              <div
+              class="wb wb--connect wb--phase"
+              title="TCP Connect: 28 ms"
+              style="left:20.9618%;width:3.4525%"
+            ></div>
+              <div
+              class="wb wb--ssl wb--phase"
+              title="TLS Handshake: 18 ms"
+              style="left:24.4143%;width:2.2195%"
+            ></div>
+              <div
+              class="wb wb--font-light"
+              title="Send+Wait: 41 ms"
+              style="left:26.6338%;width:5.0555%"
+            ></div>
+              <div
+              class="wb wb--font-dark"
+              title="Receive: 58 ms"
+              style="left:31.6893%;width:7.1517%"
+            ></div>
+          <span class="wf-bar-dur">157 ms</span>
+        </div>
+      </span>
+      </li>
+        <li
+        class="wf-row wf-row--rh26"
+        data-index="6"
+        data-started="2024-01-15T10:00:00.200Z"
+        data-time="410"
+        data-blocked="0"
+
+        data-dns="8"
+        data-connect="22"
+        data-ssl="14"
+        data-send="1"
+        data-wait="55"
+        data-receive="310"
+        data-body-size="95000"
+         data-transfer-size="68400"
+      >
+        <span class="wf-cell wf-cell--idx">7</span>
+        <span class="wf-cell wf-cell--url" title="https://cdn.example.com/hero.webp"
+          ><span class="wf-url-domain">cdn.example.com</span><span class="wf-url-path">/hero.webp</span></span
+        >
+        <span class="wf-cell wf-cell--info">GET</span>
+        <span class="wf-cell wf-cell--info">h2</span>
+        <span class="wf-cell wf-cell--info wf-cell--stat s2xx"
+          >200</span
+        >
+        <span class="wf-cell wf-cell--info">image</span>
+        <span class="wf-cell wf-cell--info wf-cell--size">66.8 KB</span>
+        <span class="wf-cell wf-cell--info wf-cell--dur">410 ms</span>
+        <span
+        class="wf-cell wf-cell--timeline"
+        style="--wf-bar-end:75.2158%"
+      >
+        <div class="wf-bar-wrap">
+          <div
+              class="wb wb--dns wb--phase"
+              title="DNS Lookup: 8 ms"
+              style="left:24.6609%;width:0.9864%"
+            ></div>
+              <div
+              class="wb wb--connect wb--phase"
+              title="TCP Connect: 22 ms"
+              style="left:25.6473%;width:2.7127%"
+            ></div>
+              <div
+              class="wb wb--ssl wb--phase"
+              title="TLS Handshake: 14 ms"
+              style="left:28.3600%;width:1.7263%"
+            ></div>
+              <div
+              class="wb wb--image-light"
+              title="Send+Wait: 56 ms"
+              style="left:30.0863%;width:6.9051%"
+            ></div>
+              <div
+              class="wb wb--image-dark"
+              title="Receive: 310 ms"
+              style="left:36.9914%;width:38.2244%"
+            ></div>
+          <span class="wf-bar-dur">410 ms</span>
+        </div>
+      </span>
+      </li>
+        <li
+        class="wf-row wf-row--rh26"
+        data-index="7"
+        data-started="2024-01-15T10:00:00.205Z"
+        data-time="31"
+        data-blocked="0"
+
+        data-dns="0"
+        data-connect="0"
+        data-ssl="0"
+        data-send="1"
+        data-wait="12"
+        data-receive="18"
+        data-body-size="2100"
+         data-transfer-size="1512"
+      >
+        <span class="wf-cell wf-cell--idx">8</span>
+        <span class="wf-cell wf-cell--url" title="https://cdn.example.com/logo.svg"
+          ><span class="wf-url-domain">cdn.example.com</span><span class="wf-url-path">/logo.svg</span></span
+        >
+        <span class="wf-cell wf-cell--info">GET</span>
+        <span class="wf-cell wf-cell--info">h2</span>
+        <span class="wf-cell wf-cell--info wf-cell--stat s2xx"
+          >200</span
+        >
+        <span class="wf-cell wf-cell--info">image</span>
+        <span class="wf-cell wf-cell--info wf-cell--size">1.5 KB</span>
+        <span class="wf-cell wf-cell--info wf-cell--dur">31 ms</span>
+        <span
+        class="wf-cell wf-cell--timeline"
+        style="--wf-bar-end:29.0999%"
+      >
+        <div class="wf-bar-wrap">
+          <div
+              class="wb wb--image-light"
+              title="Send+Wait: 13 ms"
+              style="left:25.2774%;width:1.6030%"
+            ></div>
+              <div
+              class="wb wb--image-dark"
+              title="Receive: 18 ms"
+              style="left:26.8804%;width:2.2195%"
+            ></div>
+          <span class="wf-bar-dur">31 ms</span>
+        </div>
+      </span>
+      </li>
+        <li
+        class="wf-row wf-row--rh26 row--blocking"
+        data-index="8"
+        data-started="2024-01-15T10:00:00.360Z"
+        data-time="299"
+        data-blocked="130"
+
+        data-dns="18"
+        data-connect="38"
+        data-ssl="22"
+        data-send="1"
+        data-wait="62"
+        data-receive="28"
+        data-body-size="5200"
+         data-transfer-size="3744"
+      >
+        <span class="wf-cell wf-cell--idx">9</span>
+        <span class="wf-cell wf-cell--url" title="https://analytics.example.com/pixel.js"
+          ><span class="wf-url-domain">analytics.example.com</span><span class="wf-url-path">/pixel.js</span></span
+        >
+        <span class="wf-cell wf-cell--info">GET</span>
+        <span class="wf-cell wf-cell--info">h2</span>
+        <span class="wf-cell wf-cell--info wf-cell--stat s2xx"
+          >200</span
+        >
+        <span class="wf-cell wf-cell--info">js</span>
+        <span class="wf-cell wf-cell--info wf-cell--size">3.7 KB</span>
+        <span class="wf-cell wf-cell--info wf-cell--dur">299 ms</span>
+        <span
+        class="wf-cell wf-cell--timeline"
+        style="--wf-bar-end:81.2577%"
+      >
+        <div class="wf-bar-wrap">
+          <div
+              class="wb wb--blocked wb--phase"
+              title="Blocked: 130 ms"
+              style="left:44.3896%;width:16.0296%"
+            ></div>
+              <div
+              class="wb wb--dns wb--phase"
+              title="DNS Lookup: 18 ms"
+              style="left:60.4192%;width:2.2195%"
+            ></div>
+              <div
+              class="wb wb--connect wb--phase"
+              title="TCP Connect: 38 ms"
+              style="left:62.6387%;width:4.6856%"
+            ></div>
+              <div
+              class="wb wb--ssl wb--phase"
+              title="TLS Handshake: 22 ms"
+              style="left:67.3243%;width:2.7127%"
+            ></div>
+              <div
+              class="wb wb--js-light"
+              title="Send+Wait: 63 ms"
+              style="left:70.0370%;width:7.7682%"
+            ></div>
+              <div
+              class="wb wb--js-dark"
+              title="Receive: 28 ms"
+              style="left:77.8052%;width:3.4525%"
+            ></div>
+          <span class="wf-bar-dur">299 ms</span>
+        </div>
+      </span>
+      </li>
+        <li
+        class="wf-row wf-row--rh26 row--blocking"
+        data-index="9"
+        data-started="2024-01-15T10:00:00.362Z"
+        data-time="449"
+        data-blocked="125"
+
+        data-dns="22"
+        data-connect="42"
+        data-ssl="26"
+        data-send="1"
+        data-wait="88"
+        data-receive="145"
+        data-body-size="38000"
+         data-transfer-size="27360"
+      >
+        <span class="wf-cell wf-cell--idx">10</span>
+        <span class="wf-cell wf-cell--url" title="https://cdn.thirdparty.com/widget.js"
+          ><span class="wf-url-domain">cdn.thirdparty.com</span><span class="wf-url-path">/widget.js</span></span
+        >
+        <span class="wf-cell wf-cell--info">GET</span>
+        <span class="wf-cell wf-cell--info">h2</span>
+        <span class="wf-cell wf-cell--info wf-cell--stat s2xx"
+          >200</span
+        >
+        <span class="wf-cell wf-cell--info">js</span>
+        <span class="wf-cell wf-cell--info wf-cell--size">26.7 KB</span>
+        <span class="wf-cell wf-cell--info wf-cell--dur">449 ms</span>
+        <span
+        class="wf-cell wf-cell--timeline"
+        style="--wf-bar-end:100.0000%"
+      >
+        <div class="wf-bar-wrap">
+          <div
+              class="wb wb--blocked wb--phase"
+              title="Blocked: 125 ms"
+              style="left:44.6363%;width:15.4131%"
+            ></div>
+              <div
+              class="wb wb--dns wb--phase"
+              title="DNS Lookup: 22 ms"
+              style="left:60.0493%;width:2.7127%"
+            ></div>
+              <div
+              class="wb wb--connect wb--phase"
+              title="TCP Connect: 42 ms"
+              style="left:62.7620%;width:5.1788%"
+            ></div>
+              <div
+              class="wb wb--ssl wb--phase"
+              title="TLS Handshake: 26 ms"
+              style="left:67.9408%;width:3.2059%"
+            ></div>
+              <div
+              class="wb wb--js-light"
+              title="Send+Wait: 89 ms"
+              style="left:71.1467%;width:10.9741%"
+            ></div>
+              <div
+              class="wb wb--js-dark"
+              title="Receive: 145 ms"
+              style="left:82.1208%;width:17.8792%"
+            ></div>
+          <span class="wf-bar-dur">449 ms</span>
+        </div>
+      </span>
+      </li>
+        <li
+        class="wf-row wf-row--rh26"
+        data-index="10"
+        data-started="2024-01-15T10:00:00.390Z"
+        data-time="114"
+        data-blocked="0"
+
+        data-dns="0"
+        data-connect="0"
+        data-ssl="0"
+        data-send="1"
+        data-wait="18"
+        data-receive="95"
+        data-body-size="28000"
+         data-transfer-size="20160"
+      >
+        <span class="wf-cell wf-cell--idx">11</span>
+        <span class="wf-cell wf-cell--url" title="https://cdn.example.com/thumbnail-1.webp"
+          ><span class="wf-url-domain">cdn.example.com</span><span class="wf-url-path">/thumbnail-1.webp</span></span
+        >
+        <span class="wf-cell wf-cell--info">GET</span>
+        <span class="wf-cell wf-cell--info">h2</span>
+        <span class="wf-cell wf-cell--info wf-cell--stat s2xx"
+          >200</span
+        >
+        <span class="wf-cell wf-cell--info">image</span>
+        <span class="wf-cell wf-cell--info wf-cell--size">19.7 KB</span>
+        <span class="wf-cell wf-cell--info wf-cell--dur">114 ms</span>
+        <span
+        class="wf-cell wf-cell--timeline"
+        style="--wf-bar-end:62.1455%"
+      >
+        <div class="wf-bar-wrap">
+          <div
+              class="wb wb--image-light"
+              title="Send+Wait: 19 ms"
+              style="left:48.0888%;width:2.3428%"
+            ></div>
+              <div
+              class="wb wb--image-dark"
+              title="Receive: 95 ms"
+              style="left:50.4316%;width:11.7139%"
+            ></div>
+          <span class="wf-bar-dur">114 ms</span>
+        </div>
+      </span>
+      </li>
+        <li
+        class="wf-row wf-row--rh26"
+        data-index="11"
+        data-started="2024-01-15T10:00:00.392Z"
+        data-time="123"
+        data-blocked="0"
+
+        data-dns="0"
+        data-connect="0"
+        data-ssl="0"
+        data-send="1"
+        data-wait="20"
+        data-receive="102"
+        data-body-size="31000"
+         data-transfer-size="22320"
+      >
+        <span class="wf-cell wf-cell--idx">12</span>
+        <span class="wf-cell wf-cell--url" title="https://cdn.example.com/thumbnail-2.webp"
+          ><span class="wf-url-domain">cdn.example.com</span><span class="wf-url-path">/thumbnail-2.webp</span></span
+        >
+        <span class="wf-cell wf-cell--info">GET</span>
+        <span class="wf-cell wf-cell--info">h2</span>
+        <span class="wf-cell wf-cell--info wf-cell--stat s2xx"
+          >200</span
+        >
+        <span class="wf-cell wf-cell--info">image</span>
+        <span class="wf-cell wf-cell--info wf-cell--size">21.8 KB</span>
+        <span class="wf-cell wf-cell--info wf-cell--dur">123 ms</span>
+        <span
+        class="wf-cell wf-cell--timeline"
+        style="--wf-bar-end:63.5018%"
+      >
+        <div class="wf-bar-wrap">
+          <div
+              class="wb wb--image-light"
+              title="Send+Wait: 21 ms"
+              style="left:48.3354%;width:2.5894%"
+            ></div>
+              <div
+              class="wb wb--image-dark"
+              title="Receive: 102 ms"
+              style="left:50.9248%;width:12.5771%"
+            ></div>
+          <span class="wf-bar-dur">123 ms</span>
+        </div>
+      </span>
+      </li>
+        <li
+        class="wf-row wf-row--rh26"
+        data-index="12"
+        data-started="2024-01-15T10:00:00.395Z"
+        data-time="111"
+        data-blocked="0"
+
+        data-dns="0"
+        data-connect="0"
+        data-ssl="0"
+        data-send="1"
+        data-wait="22"
+        data-receive="88"
+        data-body-size="24500"
+         data-transfer-size="17640"
+      >
+        <span class="wf-cell wf-cell--idx">13</span>
+        <span class="wf-cell wf-cell--url" title="https://cdn.example.com/thumbnail-3.webp"
+          ><span class="wf-url-domain">cdn.example.com</span><span class="wf-url-path">/thumbnail-3.webp</span></span
+        >
+        <span class="wf-cell wf-cell--info">GET</span>
+        <span class="wf-cell wf-cell--info">h2</span>
+        <span class="wf-cell wf-cell--info wf-cell--stat s2xx"
+          >200</span
+        >
+        <span class="wf-cell wf-cell--info">image</span>
+        <span class="wf-cell wf-cell--info wf-cell--size">17.2 KB</span>
+        <span class="wf-cell wf-cell--info wf-cell--dur">111 ms</span>
+        <span
+        class="wf-cell wf-cell--timeline"
+        style="--wf-bar-end:62.3921%"
+      >
+        <div class="wf-bar-wrap">
+          <div
+              class="wb wb--image-light"
+              title="Send+Wait: 23 ms"
+              style="left:48.7053%;width:2.8360%"
+            ></div>
+              <div
+              class="wb wb--image-dark"
+              title="Receive: 88 ms"
+              style="left:51.5413%;width:10.8508%"
+            ></div>
+          <span class="wf-bar-dur">111 ms</span>
+        </div>
+      </span>
+      </li>
+        <li
+        class="wf-row wf-row--rh26"
+        data-index="13"
+        data-started="2024-01-15T10:00:00.420Z"
+        data-time="108"
+        data-blocked="0"
+
+        data-dns="10"
+        data-connect="24"
+        data-ssl="16"
+        data-send="1"
+        data-wait="45"
+        data-receive="12"
+        data-body-size="1800"
+         data-transfer-size="1296"
+      >
+        <span class="wf-cell wf-cell--idx">14</span>
+        <span class="wf-cell wf-cell--url" title="https://api.example.com/v1/config"
+          ><span class="wf-url-domain">api.example.com</span><span class="wf-url-path">/v1/config</span></span
+        >
+        <span class="wf-cell wf-cell--info">GET</span>
+        <span class="wf-cell wf-cell--info">h2</span>
+        <span class="wf-cell wf-cell--info wf-cell--stat s2xx"
+          >200</span
+        >
+        <span class="wf-cell wf-cell--info">other</span>
+        <span class="wf-cell wf-cell--info wf-cell--size">1.3 KB</span>
+        <span class="wf-cell wf-cell--info wf-cell--dur">108 ms</span>
+        <span
+        class="wf-cell wf-cell--timeline"
+        style="--wf-bar-end:65.1048%"
+      >
+        <div class="wf-bar-wrap">
+          <div
+              class="wb wb--dns wb--phase"
+              title="DNS Lookup: 10 ms"
+              style="left:51.7879%;width:1.2330%"
+            ></div>
+              <div
+              class="wb wb--connect wb--phase"
+              title="TCP Connect: 24 ms"
+              style="left:53.0210%;width:2.9593%"
+            ></div>
+              <div
+              class="wb wb--ssl wb--phase"
+              title="TLS Handshake: 16 ms"
+              style="left:55.9803%;width:1.9729%"
+            ></div>
+              <div
+              class="wb wb--other-light"
+              title="Send+Wait: 46 ms"
+              style="left:57.9531%;width:5.6720%"
+            ></div>
+              <div
+              class="wb wb--other-dark"
+              title="Receive: 12 ms"
+              style="left:63.6252%;width:1.4797%"
+            ></div>
+          <span class="wf-bar-dur">108 ms</span>
+        </div>
+      </span>
+      </li>
+        <li
+        class="wf-row wf-row--rh26"
+        data-index="14"
+        data-started="2024-01-15T10:00:00.440Z"
+        data-time="182"
+        data-blocked="0"
+
+        data-dns="0"
+        data-connect="0"
+        data-ssl="0"
+        data-send="2"
+        data-wait="142"
+        data-receive="38"
+        data-body-size="6400"
+         data-transfer-size="4608"
+      >
+        <span class="wf-cell wf-cell--idx">15</span>
+        <span class="wf-cell wf-cell--url" title="https://api.example.com/v1/recommendations"
+          ><span class="wf-url-domain">api.example.com</span><span class="wf-url-path">/v1/recommendations</span></span
+        >
+        <span class="wf-cell wf-cell--info">GET</span>
+        <span class="wf-cell wf-cell--info">h2</span>
+        <span class="wf-cell wf-cell--info wf-cell--stat s2xx"
+          >200</span
+        >
+        <span class="wf-cell wf-cell--info">other</span>
+        <span class="wf-cell wf-cell--info wf-cell--size">4.5 KB</span>
+        <span class="wf-cell wf-cell--info wf-cell--dur">182 ms</span>
+        <span
+        class="wf-cell wf-cell--timeline"
+        style="--wf-bar-end:76.6954%"
+      >
+        <div class="wf-bar-wrap">
+          <div
+              class="wb wb--other-light"
+              title="Send+Wait: 144 ms"
+              style="left:54.2540%;width:17.7559%"
+            ></div>
+              <div
+              class="wb wb--other-dark"
+              title="Receive: 38 ms"
+              style="left:72.0099%;width:4.6856%"
+            ></div>
+          <span class="wf-bar-dur">182 ms</span>
+        </div>
+      </span>
+      </li>
+            </ol>
+          </div>
+
+          <p class="wf-message wf-loading" aria-live="polite" hidden>
+            Loading waterfall…
+          </p>
+          <p class="wf-message wf-message--error wf-error" hidden></p>
+    <!-- wf-demo-end -->
     </waterfall-chart>
   </body>
 </html>

--- a/packages/waterfall/public/index.html
+++ b/packages/waterfall/public/index.html
@@ -11,6 +11,8 @@
 
     <script defer src="/theme.js"></script>
     <script defer src="/progressive.js"></script>
+
+    <script type="application/wf-lazy" src="/waterfall/waterfall.js"></script>
   </head>
   <body>
     <header class="demo-header">

--- a/packages/waterfall/public/interactive.html
+++ b/packages/waterfall/public/interactive.html
@@ -25,18 +25,42 @@
           <li><a href="src-attr.html">src attribute</a></li>
         </ul>
       </nav>
-      <label
-        class="theme-toggle"
-        aria-label="Toggle colour theme"
-        title="Toggle colour theme"
-      >
-        <span class="theme-toggle__icon">☀️</span>
-        <input type="checkbox" id="theme-btn" />
-        <span class="theme-toggle__track"
-          ><span class="theme-toggle__knob"></span
-        ></span>
-        <span class="theme-toggle__icon">🌙</span>
-      </label>
+      <div class="header-actions">
+        <a
+          class="github-link"
+          href="https://github.com/cloudflare/telescope/tree/main/packages/waterfall#readme"
+          target="_blank"
+          rel="noopener noreferrer"
+          aria-label="View on GitHub"
+          title="View on GitHub"
+        >
+          <svg
+            class="github-link__icon"
+            xmlns="http://www.w3.org/2000/svg"
+            viewBox="0 0 24 24"
+            width="20"
+            height="20"
+            aria-hidden="true"
+          >
+            <path
+              fill="currentColor"
+              d="M12 .5C5.73.5.5 5.74.5 12.02c0 5.08 3.29 9.39 7.86 10.91.58.11.79-.25.79-.56 0-.28-.01-1.02-.02-2-3.2.7-3.87-1.54-3.87-1.54-.52-1.33-1.28-1.68-1.28-1.68-1.04-.71.08-.7.08-.7 1.16.08 1.77 1.19 1.77 1.19 1.03 1.76 2.7 1.25 3.36.96.1-.75.4-1.25.73-1.54-2.55-.29-5.24-1.28-5.24-5.69 0-1.26.45-2.29 1.18-3.09-.12-.29-.51-1.46.11-3.05 0 0 .97-.31 3.18 1.18a11 11 0 0 1 2.9-.39c.98 0 1.97.13 2.9.39 2.2-1.49 3.17-1.18 3.17-1.18.63 1.59.24 2.76.12 3.05.74.8 1.18 1.83 1.18 3.09 0 4.42-2.69 5.39-5.26 5.68.41.35.77 1.05.77 2.11 0 1.53-.01 2.76-.01 3.13 0 .31.21.68.8.56 4.56-1.53 7.85-5.83 7.85-10.91C23.5 5.74 18.27.5 12 .5z"
+            />
+          </svg>
+        </a>
+        <label
+          class="theme-toggle"
+          aria-label="Toggle colour theme"
+          title="Toggle colour theme"
+        >
+          <span class="theme-toggle__icon">☀️</span>
+          <input type="checkbox" id="theme-btn" />
+          <span class="theme-toggle__track"
+            ><span class="theme-toggle__knob"></span
+          ></span>
+          <span class="theme-toggle__icon">🌙</span>
+        </label>
+      </div>
     </header>
 
     <h1>Interactive</h1>
@@ -62,33 +86,45 @@
 
     <waterfall-chart id="wf">
       <!-- wf-demo-start -->
-      <div class="wf-toolbar">
+    <div class="wf-toolbar">
         <div
           class="wf-legend-group wf-filters"
           role="group"
           aria-label="Filter by resource type"
         >
-          <button type="button" class="wf-filter-btn active">all</button>
-          <button type="button" class="wf-filter-btn">
-            <span class="wf-swatch wf-swatch--thick wf-swatch--html"></span>HTML
-          </button>
-          <button type="button" class="wf-filter-btn">
-            <span class="wf-swatch wf-swatch--thick wf-swatch--js"></span>JS
-          </button>
-          <button type="button" class="wf-filter-btn">
-            <span class="wf-swatch wf-swatch--thick wf-swatch--css"></span>CSS
-          </button>
-          <button type="button" class="wf-filter-btn">
-            <span class="wf-swatch wf-swatch--thick wf-swatch--image"></span
-            >image
-          </button>
-          <button type="button" class="wf-filter-btn">
-            <span class="wf-swatch wf-swatch--thick wf-swatch--font"></span>font
-          </button>
-          <button type="button" class="wf-filter-btn">
-            <span class="wf-swatch wf-swatch--thick wf-swatch--other"></span
-            >other
-          </button>
+          <button type="button" class="wf-filter-btn active">
+          all
+        </button>
+        <button type="button" class="wf-filter-btn">
+          <span
+              class="wf-swatch wf-swatch--thick wf-swatch--html"
+            ></span>HTML
+        </button>
+        <button type="button" class="wf-filter-btn">
+          <span
+              class="wf-swatch wf-swatch--thick wf-swatch--js"
+            ></span>JS
+        </button>
+        <button type="button" class="wf-filter-btn">
+          <span
+              class="wf-swatch wf-swatch--thick wf-swatch--css"
+            ></span>CSS
+        </button>
+        <button type="button" class="wf-filter-btn">
+          <span
+              class="wf-swatch wf-swatch--thick wf-swatch--image"
+            ></span>image
+        </button>
+        <button type="button" class="wf-filter-btn">
+          <span
+              class="wf-swatch wf-swatch--thick wf-swatch--font"
+            ></span>font
+        </button>
+        <button type="button" class="wf-filter-btn">
+          <span
+              class="wf-swatch wf-swatch--thick wf-swatch--other"
+            ></span>other
+        </button>
         </div>
         <div
           class="wf-legend-group"
@@ -99,29 +135,33 @@
             <span class="wf-swatch wf-swatch--thin wf-swatch--blocked"></span
             >Blocked
           </button>
-          <button type="button" class="wf-filter-btn" data-phase="dns">
-            <span class="wf-swatch wf-swatch--thin wf-swatch--dns"></span>DNS
-            Lookup
+        <button type="button" class="wf-filter-btn" data-phase="dns">
+            <span class="wf-swatch wf-swatch--thin wf-swatch--dns"></span
+            >DNS Lookup
           </button>
-          <button type="button" class="wf-filter-btn" data-phase="connect">
+        <button type="button" class="wf-filter-btn" data-phase="connect">
             <span class="wf-swatch wf-swatch--thin wf-swatch--connect"></span
             >TCP Connect
           </button>
-          <button type="button" class="wf-filter-btn" data-phase="ssl">
-            <span class="wf-swatch wf-swatch--thin wf-swatch--ssl"></span>TLS
-            Handshake
+        <button type="button" class="wf-filter-btn" data-phase="ssl">
+            <span class="wf-swatch wf-swatch--thin wf-swatch--ssl"></span
+            >TLS Handshake
           </button>
         </div>
-        <div class="wf-legend-group" role="group" aria-label="Toggle metrics">
-          <button
+        <div
+              class="wf-legend-group"
+              role="group"
+              aria-label="Toggle metrics"
+            >
+              <button
             type="button"
             class="wf-filter-btn active"
             data-event="ev-dcl"
           >
-            <span class="wf-swatch wf-swatch--thin wf-swatch--ev-dcl"></span>DOM
-            Content Loaded
+            <span class="wf-swatch wf-swatch--thin wf-swatch--ev-dcl"></span
+            >DOM Content Loaded
           </button>
-          <button
+        <button
             type="button"
             class="wf-filter-btn active"
             data-event="ev-load"
@@ -129,7 +169,7 @@
             <span class="wf-swatch wf-swatch--thin wf-swatch--ev-load"></span
             >Page Load
           </button>
-          <button
+        <button
             type="button"
             class="wf-filter-btn active"
             data-event="ev-lcp"
@@ -137,889 +177,921 @@
             <span class="wf-swatch wf-swatch--thin wf-swatch--ev-lcp"></span
             >Largest Contentful Paint
           </button>
-        </div>
+            </div>
       </div>
 
-      <div class="wf-list-wrap">
-        <div class="wf-col-headers" aria-hidden="true">
-          <div class="wf-col-header wf-col-header--idx">#</div>
-          <div class="wf-col-header wf-col-header--url">URL</div>
-          <div class="wf-col-header wf-col-header--info">Method</div>
-          <div class="wf-col-header wf-col-header--info">Protocol</div>
-          <div class="wf-col-header wf-col-header--info">Status</div>
-          <div class="wf-col-header wf-col-header--info">Type</div>
-          <div class="wf-col-header wf-col-header--info wf-col-header--size">
-            Size
-          </div>
-          <div class="wf-col-header wf-col-header--info wf-col-header--dur">
-            Duration
-          </div>
-          <div class="wf-col-header wf-col-header--timeline">
-            <div class="wf-ruler" aria-hidden="true">
-              <span class="wf-tick" style="left: 24.6609%">0.2s</span>
-              <span class="wf-tick" style="left: 49.3218%">0.4s</span>
-              <span class="wf-tick" style="left: 73.9827%">0.6s</span>
-              <span class="wf-tick" style="left: 98.6436%">0.8s</span>
+          <div class="wf-list-wrap">
+            <div class="wf-col-headers" aria-hidden="true">
+              <div class="wf-col-header wf-col-header--idx">#</div>
+              <div class="wf-col-header wf-col-header--url">URL</div>
+              <div class="wf-col-header wf-col-header--info">Method</div>
+              <div class="wf-col-header wf-col-header--info">Protocol</div>
+              <div class="wf-col-header wf-col-header--info">Status</div>
+              <div class="wf-col-header wf-col-header--info">Type</div>
+              <div class="wf-col-header wf-col-header--info wf-col-header--size">
+                Size
+              </div>
+              <div class="wf-col-header wf-col-header--info wf-col-header--dur">
+                Duration
+              </div>
+              <div class="wf-col-header wf-col-header--timeline">
+                <div class="wf-ruler" aria-hidden="true"><span
+            class="wf-tick"
+            style="left:24.6609%"
+            >0.2s</span
+          >
+          <span
+            class="wf-tick"
+            style="left:49.3218%"
+            >0.4s</span
+          >
+          <span
+            class="wf-tick"
+            style="left:73.9827%"
+            >0.6s</span
+          >
+          <span
+            class="wf-tick"
+            style="left:98.6436%"
+            >0.8s</span
+          ></div>
+                <div class="wf-grid-overlay" aria-hidden="true">
+                  <div
+              class="wf-grid-line"
+              style="left:24.6609%"
+            ></div>
+          <div
+              class="wf-grid-line"
+              style="left:49.3218%"
+            ></div>
+          <div
+              class="wf-grid-line"
+              style="left:73.9827%"
+            ></div>
+          <div
+              class="wf-grid-line"
+              style="left:98.6436%"
+            ></div>
+                </div>
+                <div class="wf-events-overlay" aria-hidden="true">
+                  <div
+            class="wf-event-line wf-event--dcl"
+            data-ms="340"
+            data-label="DCL 340 ms"
+            data-name="DCL"
+            style="left:41.9236%"
+          ></div>
+          <div
+            class="wf-event-line wf-event--load"
+            data-ms="620"
+            data-label="Load 620 ms"
+            data-name="Load"
+            style="left:76.4488%"
+          ></div>
+          <div
+            class="wf-event-line wf-event--lcp"
+            data-ms="480"
+            data-label="LCP 480 ms"
+            data-name="LCP"
+            style="left:59.1862%"
+          ></div>
+                </div>
+              </div>
             </div>
-            <div class="wf-grid-overlay" aria-hidden="true">
-              <div class="wf-grid-line" style="left: 24.6609%"></div>
-              <div class="wf-grid-line" style="left: 49.3218%"></div>
-              <div class="wf-grid-line" style="left: 73.9827%"></div>
-              <div class="wf-grid-line" style="left: 98.6436%"></div>
-            </div>
-            <div class="wf-events-overlay" aria-hidden="true">
-              <div
-                class="wf-event-line wf-event--dcl"
-                data-ms="340"
-                data-label="DCL 340 ms"
-                data-name="DCL"
-                style="left: 41.9236%"
-              ></div>
-              <div
-                class="wf-event-line wf-event--load"
-                data-ms="620"
-                data-label="Load 620 ms"
-                data-name="Load"
-                style="left: 76.4488%"
-              ></div>
-              <div
-                class="wf-event-line wf-event--lcp"
-                data-ms="480"
-                data-label="LCP 480 ms"
-                data-name="LCP"
-                style="left: 59.1862%"
-              ></div>
-            </div>
-          </div>
-        </div>
-        <ol class="wf-list" aria-label="Network requests">
-          <li
-            class="wf-row wf-row--rh26"
-            data-index="0"
-            data-started="2024-01-15T10:00:00.000Z"
-            data-time="164"
-            data-blocked="12"
-            data-dns="0"
-            data-connect="0"
-            data-ssl="0"
-            data-send="6"
-            data-wait="28"
-            data-receive="118"
-            data-body-size="18200"
-            data-transfer-size="13104"
-          >
-            <span class="wf-cell wf-cell--idx">1</span>
-            <span class="wf-cell wf-cell--url" title="https://example.com/"
-              ><span class="wf-url-domain">example.com</span></span
-            >
-            <span class="wf-cell wf-cell--info">GET</span>
-            <span class="wf-cell wf-cell--info">h2</span>
-            <span class="wf-cell wf-cell--info wf-cell--stat s2xx">200</span>
-            <span class="wf-cell wf-cell--info">html</span>
-            <span class="wf-cell wf-cell--info wf-cell--size">12.8 KB</span>
-            <span class="wf-cell wf-cell--info wf-cell--dur">164 ms</span>
-            <span
-              class="wf-cell wf-cell--timeline"
-              style="--wf-bar-end: 20.2219%"
-            >
-              <div class="wf-bar-wrap">
-                <div
-                  class="wb wb--blocked wb--phase"
-                  title="Blocked: 12 ms"
-                  style="left: 0%; width: 1.4797%"
-                ></div>
-                <div
-                  class="wb wb--html-light"
-                  title="Send+Wait: 34 ms"
-                  style="left: 1.4797%; width: 4.1924%"
-                ></div>
-                <div
-                  class="wb wb--html-dark"
-                  title="Receive: 118 ms"
-                  style="left: 5.672%; width: 14.5499%"
-                ></div>
-                <span class="wf-bar-dur">164 ms</span>
-              </div>
-            </span>
-          </li>
-          <li
-            class="wf-row wf-row--rh26"
-            data-index="1"
-            data-started="2024-01-15T10:00:00.148Z"
-            data-time="53"
-            data-blocked="2"
-            data-dns="0"
-            data-connect="0"
-            data-ssl="0"
-            data-send="1"
-            data-wait="18"
-            data-receive="32"
-            data-body-size="4800"
-            data-transfer-size="3456"
-          >
-            <span class="wf-cell wf-cell--idx">2</span>
-            <span
-              class="wf-cell wf-cell--url"
-              title="https://example.com/assets/main.css"
-              ><span class="wf-url-domain">example.com</span
-              ><span class="wf-url-path">/assets/main.css</span></span
-            >
-            <span class="wf-cell wf-cell--info">GET</span>
-            <span class="wf-cell wf-cell--info">h2</span>
-            <span class="wf-cell wf-cell--info wf-cell--stat s2xx">200</span>
-            <span class="wf-cell wf-cell--info">css</span>
-            <span class="wf-cell wf-cell--info wf-cell--size">3.4 KB</span>
-            <span class="wf-cell wf-cell--info wf-cell--dur">53 ms</span>
-            <span
-              class="wf-cell wf-cell--timeline"
-              style="--wf-bar-end: 24.7842%"
-            >
-              <div class="wf-bar-wrap">
-                <div
-                  class="wb wb--blocked wb--phase"
-                  title="Blocked: 2 ms"
-                  style="left: 18.2491%; width: 0.2466%"
-                ></div>
-                <div
-                  class="wb wb--css-light"
-                  title="Send+Wait: 19 ms"
-                  style="left: 18.4957%; width: 2.3428%"
-                ></div>
-                <div
-                  class="wb wb--css-dark"
-                  title="Receive: 32 ms"
-                  style="left: 20.8385%; width: 3.9457%"
-                ></div>
-                <span class="wf-bar-dur">53 ms</span>
-              </div>
-            </span>
-          </li>
-          <li
-            class="wf-row wf-row--rh26"
-            data-index="2"
-            data-started="2024-01-15T10:00:00.150Z"
-            data-time="80"
-            data-blocked="2"
-            data-dns="0"
-            data-connect="0"
-            data-ssl="0"
-            data-send="1"
-            data-wait="22"
-            data-receive="55"
-            data-body-size="12400"
-            data-transfer-size="8928"
-          >
-            <span class="wf-cell wf-cell--idx">3</span>
-            <span
-              class="wf-cell wf-cell--url"
-              title="https://example.com/assets/runtime.js"
-              ><span class="wf-url-domain">example.com</span
-              ><span class="wf-url-path">/assets/runtime.js</span></span
-            >
-            <span class="wf-cell wf-cell--info">GET</span>
-            <span class="wf-cell wf-cell--info">h2</span>
-            <span class="wf-cell wf-cell--info wf-cell--stat s2xx">200</span>
-            <span class="wf-cell wf-cell--info">js</span>
-            <span class="wf-cell wf-cell--info wf-cell--size">8.7 KB</span>
-            <span class="wf-cell wf-cell--info wf-cell--dur">80 ms</span>
-            <span
-              class="wf-cell wf-cell--timeline"
-              style="--wf-bar-end: 28.36%"
-            >
-              <div class="wf-bar-wrap">
-                <div
-                  class="wb wb--blocked wb--phase"
-                  title="Blocked: 2 ms"
-                  style="left: 18.4957%; width: 0.2466%"
-                ></div>
-                <div
-                  class="wb wb--js-light"
-                  title="Send+Wait: 23 ms"
-                  style="left: 18.7423%; width: 2.836%"
-                ></div>
-                <div
-                  class="wb wb--js-dark"
-                  title="Receive: 55 ms"
-                  style="left: 21.5783%; width: 6.7818%"
-                ></div>
-                <span class="wf-bar-dur">80 ms</span>
-              </div>
-            </span>
-          </li>
-          <li
-            class="wf-row wf-row--rh26"
-            data-index="3"
-            data-started="2024-01-15T10:00:00.152Z"
-            data-time="208"
-            data-blocked="2"
-            data-dns="0"
-            data-connect="0"
-            data-ssl="0"
-            data-send="1"
-            data-wait="25"
-            data-receive="180"
-            data-body-size="68000"
-            data-transfer-size="48960"
-          >
-            <span class="wf-cell wf-cell--idx">4</span>
-            <span
-              class="wf-cell wf-cell--url"
-              title="https://example.com/assets/app.js"
-              ><span class="wf-url-domain">example.com</span
-              ><span class="wf-url-path">/assets/app.js</span></span
-            >
-            <span class="wf-cell wf-cell--info">GET</span>
-            <span class="wf-cell wf-cell--info">h2</span>
-            <span class="wf-cell wf-cell--info wf-cell--stat s2xx">200</span>
-            <span class="wf-cell wf-cell--info">js</span>
-            <span class="wf-cell wf-cell--info wf-cell--size">47.8 KB</span>
-            <span class="wf-cell wf-cell--info wf-cell--dur">208 ms</span>
-            <span
-              class="wf-cell wf-cell--timeline"
-              style="--wf-bar-end: 44.3896%"
-            >
-              <div class="wf-bar-wrap">
-                <div
-                  class="wb wb--blocked wb--phase"
-                  title="Blocked: 2 ms"
-                  style="left: 18.7423%; width: 0.2466%"
-                ></div>
-                <div
-                  class="wb wb--js-light"
-                  title="Send+Wait: 26 ms"
-                  style="left: 18.9889%; width: 3.2059%"
-                ></div>
-                <div
-                  class="wb wb--js-dark"
-                  title="Receive: 180 ms"
-                  style="left: 22.1948%; width: 22.1948%"
-                ></div>
-                <span class="wf-bar-dur">208 ms</span>
-              </div>
-            </span>
-          </li>
-          <li
-            class="wf-row wf-row--rh26"
-            data-index="4"
-            data-started="2024-01-15T10:00:00.155Z"
-            data-time="159"
-            data-blocked="0"
-            data-dns="12"
-            data-connect="28"
-            data-ssl="18"
-            data-send="1"
-            data-wait="38"
-            data-receive="62"
-            data-body-size="22000"
-            data-transfer-size="15840"
-          >
-            <span class="wf-cell wf-cell--idx">5</span>
-            <span
-              class="wf-cell wf-cell--url"
-              title="https://fonts.example.com/inter-400.woff2"
-              ><span class="wf-url-domain">fonts.example.com</span
-              ><span class="wf-url-path">/inter-400.woff2</span></span
-            >
-            <span class="wf-cell wf-cell--info">GET</span>
-            <span class="wf-cell wf-cell--info">h2</span>
-            <span class="wf-cell wf-cell--info wf-cell--stat s2xx">200</span>
-            <span class="wf-cell wf-cell--info">font</span>
-            <span class="wf-cell wf-cell--info wf-cell--size">15.5 KB</span>
-            <span class="wf-cell wf-cell--info wf-cell--dur">159 ms</span>
-            <span
-              class="wf-cell wf-cell--timeline"
-              style="--wf-bar-end: 38.7176%"
-            >
-              <div class="wf-bar-wrap">
-                <div
-                  class="wb wb--dns wb--phase"
-                  title="DNS Lookup: 12 ms"
-                  style="left: 19.1122%; width: 1.4797%"
-                ></div>
-                <div
-                  class="wb wb--connect wb--phase"
-                  title="TCP Connect: 28 ms"
-                  style="left: 20.5919%; width: 3.4525%"
-                ></div>
-                <div
-                  class="wb wb--ssl wb--phase"
-                  title="TLS Handshake: 18 ms"
-                  style="left: 24.0444%; width: 2.2195%"
-                ></div>
-                <div
-                  class="wb wb--font-light"
-                  title="Send+Wait: 39 ms"
-                  style="left: 26.2639%; width: 4.8089%"
-                ></div>
-                <div
-                  class="wb wb--font-dark"
-                  title="Receive: 62 ms"
-                  style="left: 31.0727%; width: 7.6449%"
-                ></div>
-                <span class="wf-bar-dur">159 ms</span>
-              </div>
-            </span>
-          </li>
-          <li
-            class="wf-row wf-row--rh26"
-            data-index="5"
-            data-started="2024-01-15T10:00:00.158Z"
-            data-time="157"
-            data-blocked="0"
-            data-dns="12"
-            data-connect="28"
-            data-ssl="18"
-            data-send="1"
-            data-wait="40"
-            data-receive="58"
-            data-body-size="19500"
-            data-transfer-size="14040"
-          >
-            <span class="wf-cell wf-cell--idx">6</span>
-            <span
-              class="wf-cell wf-cell--url"
-              title="https://fonts.example.com/inter-600.woff2"
-              ><span class="wf-url-domain">fonts.example.com</span
-              ><span class="wf-url-path">/inter-600.woff2</span></span
-            >
-            <span class="wf-cell wf-cell--info">GET</span>
-            <span class="wf-cell wf-cell--info">h2</span>
-            <span class="wf-cell wf-cell--info wf-cell--stat s2xx">200</span>
-            <span class="wf-cell wf-cell--info">font</span>
-            <span class="wf-cell wf-cell--info wf-cell--size">13.7 KB</span>
-            <span class="wf-cell wf-cell--info wf-cell--dur">157 ms</span>
-            <span
-              class="wf-cell wf-cell--timeline"
-              style="--wf-bar-end: 38.8409%"
-            >
-              <div class="wf-bar-wrap">
-                <div
-                  class="wb wb--dns wb--phase"
-                  title="DNS Lookup: 12 ms"
-                  style="left: 19.4821%; width: 1.4797%"
-                ></div>
-                <div
-                  class="wb wb--connect wb--phase"
-                  title="TCP Connect: 28 ms"
-                  style="left: 20.9618%; width: 3.4525%"
-                ></div>
-                <div
-                  class="wb wb--ssl wb--phase"
-                  title="TLS Handshake: 18 ms"
-                  style="left: 24.4143%; width: 2.2195%"
-                ></div>
-                <div
-                  class="wb wb--font-light"
-                  title="Send+Wait: 41 ms"
-                  style="left: 26.6338%; width: 5.0555%"
-                ></div>
-                <div
-                  class="wb wb--font-dark"
-                  title="Receive: 58 ms"
-                  style="left: 31.6893%; width: 7.1517%"
-                ></div>
-                <span class="wf-bar-dur">157 ms</span>
-              </div>
-            </span>
-          </li>
-          <li
-            class="wf-row wf-row--rh26"
-            data-index="6"
-            data-started="2024-01-15T10:00:00.200Z"
-            data-time="410"
-            data-blocked="0"
-            data-dns="8"
-            data-connect="22"
-            data-ssl="14"
-            data-send="1"
-            data-wait="55"
-            data-receive="310"
-            data-body-size="95000"
-            data-transfer-size="68400"
-          >
-            <span class="wf-cell wf-cell--idx">7</span>
-            <span
-              class="wf-cell wf-cell--url"
-              title="https://cdn.example.com/hero.webp"
-              ><span class="wf-url-domain">cdn.example.com</span
-              ><span class="wf-url-path">/hero.webp</span></span
-            >
-            <span class="wf-cell wf-cell--info">GET</span>
-            <span class="wf-cell wf-cell--info">h2</span>
-            <span class="wf-cell wf-cell--info wf-cell--stat s2xx">200</span>
-            <span class="wf-cell wf-cell--info">image</span>
-            <span class="wf-cell wf-cell--info wf-cell--size">66.8 KB</span>
-            <span class="wf-cell wf-cell--info wf-cell--dur">410 ms</span>
-            <span
-              class="wf-cell wf-cell--timeline"
-              style="--wf-bar-end: 75.2158%"
-            >
-              <div class="wf-bar-wrap">
-                <div
-                  class="wb wb--dns wb--phase"
-                  title="DNS Lookup: 8 ms"
-                  style="left: 24.6609%; width: 0.9864%"
-                ></div>
-                <div
-                  class="wb wb--connect wb--phase"
-                  title="TCP Connect: 22 ms"
-                  style="left: 25.6473%; width: 2.7127%"
-                ></div>
-                <div
-                  class="wb wb--ssl wb--phase"
-                  title="TLS Handshake: 14 ms"
-                  style="left: 28.36%; width: 1.7263%"
-                ></div>
-                <div
-                  class="wb wb--image-light"
-                  title="Send+Wait: 56 ms"
-                  style="left: 30.0863%; width: 6.9051%"
-                ></div>
-                <div
-                  class="wb wb--image-dark"
-                  title="Receive: 310 ms"
-                  style="left: 36.9914%; width: 38.2244%"
-                ></div>
-                <span class="wf-bar-dur">410 ms</span>
-              </div>
-            </span>
-          </li>
-          <li
-            class="wf-row wf-row--rh26"
-            data-index="7"
-            data-started="2024-01-15T10:00:00.205Z"
-            data-time="31"
-            data-blocked="0"
-            data-dns="0"
-            data-connect="0"
-            data-ssl="0"
-            data-send="1"
-            data-wait="12"
-            data-receive="18"
-            data-body-size="2100"
-            data-transfer-size="1512"
-          >
-            <span class="wf-cell wf-cell--idx">8</span>
-            <span
-              class="wf-cell wf-cell--url"
-              title="https://cdn.example.com/logo.svg"
-              ><span class="wf-url-domain">cdn.example.com</span
-              ><span class="wf-url-path">/logo.svg</span></span
-            >
-            <span class="wf-cell wf-cell--info">GET</span>
-            <span class="wf-cell wf-cell--info">h2</span>
-            <span class="wf-cell wf-cell--info wf-cell--stat s2xx">200</span>
-            <span class="wf-cell wf-cell--info">image</span>
-            <span class="wf-cell wf-cell--info wf-cell--size">1.5 KB</span>
-            <span class="wf-cell wf-cell--info wf-cell--dur">31 ms</span>
-            <span
-              class="wf-cell wf-cell--timeline"
-              style="--wf-bar-end: 29.0999%"
-            >
-              <div class="wf-bar-wrap">
-                <div
-                  class="wb wb--image-light"
-                  title="Send+Wait: 13 ms"
-                  style="left: 25.2774%; width: 1.603%"
-                ></div>
-                <div
-                  class="wb wb--image-dark"
-                  title="Receive: 18 ms"
-                  style="left: 26.8804%; width: 2.2195%"
-                ></div>
-                <span class="wf-bar-dur">31 ms</span>
-              </div>
-            </span>
-          </li>
-          <li
-            class="wf-row wf-row--rh26 row--blocking"
-            data-index="8"
-            data-started="2024-01-15T10:00:00.360Z"
-            data-time="299"
-            data-blocked="130"
-            data-dns="18"
-            data-connect="38"
-            data-ssl="22"
-            data-send="1"
-            data-wait="62"
-            data-receive="28"
-            data-body-size="5200"
-            data-transfer-size="3744"
-          >
-            <span class="wf-cell wf-cell--idx">9</span>
-            <span
-              class="wf-cell wf-cell--url"
-              title="https://analytics.example.com/pixel.js"
-              ><span class="wf-url-domain">analytics.example.com</span
-              ><span class="wf-url-path">/pixel.js</span></span
-            >
-            <span class="wf-cell wf-cell--info">GET</span>
-            <span class="wf-cell wf-cell--info">h2</span>
-            <span class="wf-cell wf-cell--info wf-cell--stat s2xx">200</span>
-            <span class="wf-cell wf-cell--info">js</span>
-            <span class="wf-cell wf-cell--info wf-cell--size">3.7 KB</span>
-            <span class="wf-cell wf-cell--info wf-cell--dur">299 ms</span>
-            <span
-              class="wf-cell wf-cell--timeline"
-              style="--wf-bar-end: 81.2577%"
-            >
-              <div class="wf-bar-wrap">
-                <div
-                  class="wb wb--blocked wb--phase"
-                  title="Blocked: 130 ms"
-                  style="left: 44.3896%; width: 16.0296%"
-                ></div>
-                <div
-                  class="wb wb--dns wb--phase"
-                  title="DNS Lookup: 18 ms"
-                  style="left: 60.4192%; width: 2.2195%"
-                ></div>
-                <div
-                  class="wb wb--connect wb--phase"
-                  title="TCP Connect: 38 ms"
-                  style="left: 62.6387%; width: 4.6856%"
-                ></div>
-                <div
-                  class="wb wb--ssl wb--phase"
-                  title="TLS Handshake: 22 ms"
-                  style="left: 67.3243%; width: 2.7127%"
-                ></div>
-                <div
-                  class="wb wb--js-light"
-                  title="Send+Wait: 63 ms"
-                  style="left: 70.037%; width: 7.7682%"
-                ></div>
-                <div
-                  class="wb wb--js-dark"
-                  title="Receive: 28 ms"
-                  style="left: 77.8052%; width: 3.4525%"
-                ></div>
-                <span class="wf-bar-dur">299 ms</span>
-              </div>
-            </span>
-          </li>
-          <li
-            class="wf-row wf-row--rh26 row--blocking"
-            data-index="9"
-            data-started="2024-01-15T10:00:00.362Z"
-            data-time="449"
-            data-blocked="125"
-            data-dns="22"
-            data-connect="42"
-            data-ssl="26"
-            data-send="1"
-            data-wait="88"
-            data-receive="145"
-            data-body-size="38000"
-            data-transfer-size="27360"
-          >
-            <span class="wf-cell wf-cell--idx">10</span>
-            <span
-              class="wf-cell wf-cell--url"
-              title="https://cdn.thirdparty.com/widget.js"
-              ><span class="wf-url-domain">cdn.thirdparty.com</span
-              ><span class="wf-url-path">/widget.js</span></span
-            >
-            <span class="wf-cell wf-cell--info">GET</span>
-            <span class="wf-cell wf-cell--info">h2</span>
-            <span class="wf-cell wf-cell--info wf-cell--stat s2xx">200</span>
-            <span class="wf-cell wf-cell--info">js</span>
-            <span class="wf-cell wf-cell--info wf-cell--size">26.7 KB</span>
-            <span class="wf-cell wf-cell--info wf-cell--dur">449 ms</span>
-            <span class="wf-cell wf-cell--timeline" style="--wf-bar-end: 100%">
-              <div class="wf-bar-wrap">
-                <div
-                  class="wb wb--blocked wb--phase"
-                  title="Blocked: 125 ms"
-                  style="left: 44.6363%; width: 15.4131%"
-                ></div>
-                <div
-                  class="wb wb--dns wb--phase"
-                  title="DNS Lookup: 22 ms"
-                  style="left: 60.0493%; width: 2.7127%"
-                ></div>
-                <div
-                  class="wb wb--connect wb--phase"
-                  title="TCP Connect: 42 ms"
-                  style="left: 62.762%; width: 5.1788%"
-                ></div>
-                <div
-                  class="wb wb--ssl wb--phase"
-                  title="TLS Handshake: 26 ms"
-                  style="left: 67.9408%; width: 3.2059%"
-                ></div>
-                <div
-                  class="wb wb--js-light"
-                  title="Send+Wait: 89 ms"
-                  style="left: 71.1467%; width: 10.9741%"
-                ></div>
-                <div
-                  class="wb wb--js-dark"
-                  title="Receive: 145 ms"
-                  style="left: 82.1208%; width: 17.8792%"
-                ></div>
-                <span class="wf-bar-dur">449 ms</span>
-              </div>
-            </span>
-          </li>
-          <li
-            class="wf-row wf-row--rh26"
-            data-index="10"
-            data-started="2024-01-15T10:00:00.390Z"
-            data-time="114"
-            data-blocked="0"
-            data-dns="0"
-            data-connect="0"
-            data-ssl="0"
-            data-send="1"
-            data-wait="18"
-            data-receive="95"
-            data-body-size="28000"
-            data-transfer-size="20160"
-          >
-            <span class="wf-cell wf-cell--idx">11</span>
-            <span
-              class="wf-cell wf-cell--url"
-              title="https://cdn.example.com/thumbnail-1.webp"
-              ><span class="wf-url-domain">cdn.example.com</span
-              ><span class="wf-url-path">/thumbnail-1.webp</span></span
-            >
-            <span class="wf-cell wf-cell--info">GET</span>
-            <span class="wf-cell wf-cell--info">h2</span>
-            <span class="wf-cell wf-cell--info wf-cell--stat s2xx">200</span>
-            <span class="wf-cell wf-cell--info">image</span>
-            <span class="wf-cell wf-cell--info wf-cell--size">19.7 KB</span>
-            <span class="wf-cell wf-cell--info wf-cell--dur">114 ms</span>
-            <span
-              class="wf-cell wf-cell--timeline"
-              style="--wf-bar-end: 62.1455%"
-            >
-              <div class="wf-bar-wrap">
-                <div
-                  class="wb wb--image-light"
-                  title="Send+Wait: 19 ms"
-                  style="left: 48.0888%; width: 2.3428%"
-                ></div>
-                <div
-                  class="wb wb--image-dark"
-                  title="Receive: 95 ms"
-                  style="left: 50.4316%; width: 11.7139%"
-                ></div>
-                <span class="wf-bar-dur">114 ms</span>
-              </div>
-            </span>
-          </li>
-          <li
-            class="wf-row wf-row--rh26"
-            data-index="11"
-            data-started="2024-01-15T10:00:00.392Z"
-            data-time="123"
-            data-blocked="0"
-            data-dns="0"
-            data-connect="0"
-            data-ssl="0"
-            data-send="1"
-            data-wait="20"
-            data-receive="102"
-            data-body-size="31000"
-            data-transfer-size="22320"
-          >
-            <span class="wf-cell wf-cell--idx">12</span>
-            <span
-              class="wf-cell wf-cell--url"
-              title="https://cdn.example.com/thumbnail-2.webp"
-              ><span class="wf-url-domain">cdn.example.com</span
-              ><span class="wf-url-path">/thumbnail-2.webp</span></span
-            >
-            <span class="wf-cell wf-cell--info">GET</span>
-            <span class="wf-cell wf-cell--info">h2</span>
-            <span class="wf-cell wf-cell--info wf-cell--stat s2xx">200</span>
-            <span class="wf-cell wf-cell--info">image</span>
-            <span class="wf-cell wf-cell--info wf-cell--size">21.8 KB</span>
-            <span class="wf-cell wf-cell--info wf-cell--dur">123 ms</span>
-            <span
-              class="wf-cell wf-cell--timeline"
-              style="--wf-bar-end: 63.5018%"
-            >
-              <div class="wf-bar-wrap">
-                <div
-                  class="wb wb--image-light"
-                  title="Send+Wait: 21 ms"
-                  style="left: 48.3354%; width: 2.5894%"
-                ></div>
-                <div
-                  class="wb wb--image-dark"
-                  title="Receive: 102 ms"
-                  style="left: 50.9248%; width: 12.5771%"
-                ></div>
-                <span class="wf-bar-dur">123 ms</span>
-              </div>
-            </span>
-          </li>
-          <li
-            class="wf-row wf-row--rh26"
-            data-index="12"
-            data-started="2024-01-15T10:00:00.395Z"
-            data-time="111"
-            data-blocked="0"
-            data-dns="0"
-            data-connect="0"
-            data-ssl="0"
-            data-send="1"
-            data-wait="22"
-            data-receive="88"
-            data-body-size="24500"
-            data-transfer-size="17640"
-          >
-            <span class="wf-cell wf-cell--idx">13</span>
-            <span
-              class="wf-cell wf-cell--url"
-              title="https://cdn.example.com/thumbnail-3.webp"
-              ><span class="wf-url-domain">cdn.example.com</span
-              ><span class="wf-url-path">/thumbnail-3.webp</span></span
-            >
-            <span class="wf-cell wf-cell--info">GET</span>
-            <span class="wf-cell wf-cell--info">h2</span>
-            <span class="wf-cell wf-cell--info wf-cell--stat s2xx">200</span>
-            <span class="wf-cell wf-cell--info">image</span>
-            <span class="wf-cell wf-cell--info wf-cell--size">17.2 KB</span>
-            <span class="wf-cell wf-cell--info wf-cell--dur">111 ms</span>
-            <span
-              class="wf-cell wf-cell--timeline"
-              style="--wf-bar-end: 62.3921%"
-            >
-              <div class="wf-bar-wrap">
-                <div
-                  class="wb wb--image-light"
-                  title="Send+Wait: 23 ms"
-                  style="left: 48.7053%; width: 2.836%"
-                ></div>
-                <div
-                  class="wb wb--image-dark"
-                  title="Receive: 88 ms"
-                  style="left: 51.5413%; width: 10.8508%"
-                ></div>
-                <span class="wf-bar-dur">111 ms</span>
-              </div>
-            </span>
-          </li>
-          <li
-            class="wf-row wf-row--rh26"
-            data-index="13"
-            data-started="2024-01-15T10:00:00.420Z"
-            data-time="108"
-            data-blocked="0"
-            data-dns="10"
-            data-connect="24"
-            data-ssl="16"
-            data-send="1"
-            data-wait="45"
-            data-receive="12"
-            data-body-size="1800"
-            data-transfer-size="1296"
-          >
-            <span class="wf-cell wf-cell--idx">14</span>
-            <span
-              class="wf-cell wf-cell--url"
-              title="https://api.example.com/v1/config"
-              ><span class="wf-url-domain">api.example.com</span
-              ><span class="wf-url-path">/v1/config</span></span
-            >
-            <span class="wf-cell wf-cell--info">GET</span>
-            <span class="wf-cell wf-cell--info">h2</span>
-            <span class="wf-cell wf-cell--info wf-cell--stat s2xx">200</span>
-            <span class="wf-cell wf-cell--info">other</span>
-            <span class="wf-cell wf-cell--info wf-cell--size">1.3 KB</span>
-            <span class="wf-cell wf-cell--info wf-cell--dur">108 ms</span>
-            <span
-              class="wf-cell wf-cell--timeline"
-              style="--wf-bar-end: 65.1048%"
-            >
-              <div class="wf-bar-wrap">
-                <div
-                  class="wb wb--dns wb--phase"
-                  title="DNS Lookup: 10 ms"
-                  style="left: 51.7879%; width: 1.233%"
-                ></div>
-                <div
-                  class="wb wb--connect wb--phase"
-                  title="TCP Connect: 24 ms"
-                  style="left: 53.021%; width: 2.9593%"
-                ></div>
-                <div
-                  class="wb wb--ssl wb--phase"
-                  title="TLS Handshake: 16 ms"
-                  style="left: 55.9803%; width: 1.9729%"
-                ></div>
-                <div
-                  class="wb wb--other-light"
-                  title="Send+Wait: 46 ms"
-                  style="left: 57.9531%; width: 5.672%"
-                ></div>
-                <div
-                  class="wb wb--other-dark"
-                  title="Receive: 12 ms"
-                  style="left: 63.6252%; width: 1.4797%"
-                ></div>
-                <span class="wf-bar-dur">108 ms</span>
-              </div>
-            </span>
-          </li>
-          <li
-            class="wf-row wf-row--rh26"
-            data-index="14"
-            data-started="2024-01-15T10:00:00.440Z"
-            data-time="182"
-            data-blocked="0"
-            data-dns="0"
-            data-connect="0"
-            data-ssl="0"
-            data-send="2"
-            data-wait="142"
-            data-receive="38"
-            data-body-size="6400"
-            data-transfer-size="4608"
-          >
-            <span class="wf-cell wf-cell--idx">15</span>
-            <span
-              class="wf-cell wf-cell--url"
-              title="https://api.example.com/v1/recommendations"
-              ><span class="wf-url-domain">api.example.com</span
-              ><span class="wf-url-path">/v1/recommendations</span></span
-            >
-            <span class="wf-cell wf-cell--info">GET</span>
-            <span class="wf-cell wf-cell--info">h2</span>
-            <span class="wf-cell wf-cell--info wf-cell--stat s2xx">200</span>
-            <span class="wf-cell wf-cell--info">other</span>
-            <span class="wf-cell wf-cell--info wf-cell--size">4.5 KB</span>
-            <span class="wf-cell wf-cell--info wf-cell--dur">182 ms</span>
-            <span
-              class="wf-cell wf-cell--timeline"
-              style="--wf-bar-end: 76.6954%"
-            >
-              <div class="wf-bar-wrap">
-                <div
-                  class="wb wb--other-light"
-                  title="Send+Wait: 144 ms"
-                  style="left: 54.254%; width: 17.7559%"
-                ></div>
-                <div
-                  class="wb wb--other-dark"
-                  title="Receive: 38 ms"
-                  style="left: 72.0099%; width: 4.6856%"
-                ></div>
-                <span class="wf-bar-dur">182 ms</span>
-              </div>
-            </span>
-          </li>
-        </ol>
-      </div>
+            <ol class="wf-list" aria-label="Network requests">
+              <li
+        class="wf-row wf-row--rh26"
+        data-index="0"
+        data-started="2024-01-15T10:00:00.000Z"
+        data-time="164"
+        data-blocked="12"
 
-      <p class="wf-message wf-loading" aria-live="polite" hidden>
-        Loading waterfall…
-      </p>
-      <p class="wf-message wf-message--error wf-error" hidden></p>
-      <!-- wf-demo-end -->
+        data-dns="0"
+        data-connect="0"
+        data-ssl="0"
+        data-send="6"
+        data-wait="28"
+        data-receive="118"
+        data-body-size="18200"
+         data-transfer-size="13104"
+      >
+        <span class="wf-cell wf-cell--idx">1</span>
+        <span class="wf-cell wf-cell--url" title="https://example.com/"
+          ><span class="wf-url-domain">example.com</span></span
+        >
+        <span class="wf-cell wf-cell--info">GET</span>
+        <span class="wf-cell wf-cell--info">h2</span>
+        <span class="wf-cell wf-cell--info wf-cell--stat s2xx"
+          >200</span
+        >
+        <span class="wf-cell wf-cell--info">html</span>
+        <span class="wf-cell wf-cell--info wf-cell--size">12.8 KB</span>
+        <span class="wf-cell wf-cell--info wf-cell--dur">164 ms</span>
+        <span
+        class="wf-cell wf-cell--timeline"
+        style="--wf-bar-end:20.2219%"
+      >
+        <div class="wf-bar-wrap">
+          <div
+              class="wb wb--blocked wb--phase"
+              title="Blocked: 12 ms"
+              style="left:0.0000%;width:1.4797%"
+            ></div>
+              <div
+              class="wb wb--html-light"
+              title="Send+Wait: 34 ms"
+              style="left:1.4797%;width:4.1924%"
+            ></div>
+              <div
+              class="wb wb--html-dark"
+              title="Receive: 118 ms"
+              style="left:5.6720%;width:14.5499%"
+            ></div>
+          <span class="wf-bar-dur">164 ms</span>
+        </div>
+      </span>
+      </li>
+        <li
+        class="wf-row wf-row--rh26"
+        data-index="1"
+        data-started="2024-01-15T10:00:00.148Z"
+        data-time="53"
+        data-blocked="2"
+
+        data-dns="0"
+        data-connect="0"
+        data-ssl="0"
+        data-send="1"
+        data-wait="18"
+        data-receive="32"
+        data-body-size="4800"
+         data-transfer-size="3456"
+      >
+        <span class="wf-cell wf-cell--idx">2</span>
+        <span class="wf-cell wf-cell--url" title="https://example.com/assets/main.css"
+          ><span class="wf-url-domain">example.com</span><span class="wf-url-path">/assets/main.css</span></span
+        >
+        <span class="wf-cell wf-cell--info">GET</span>
+        <span class="wf-cell wf-cell--info">h2</span>
+        <span class="wf-cell wf-cell--info wf-cell--stat s2xx"
+          >200</span
+        >
+        <span class="wf-cell wf-cell--info">css</span>
+        <span class="wf-cell wf-cell--info wf-cell--size">3.4 KB</span>
+        <span class="wf-cell wf-cell--info wf-cell--dur">53 ms</span>
+        <span
+        class="wf-cell wf-cell--timeline"
+        style="--wf-bar-end:24.7842%"
+      >
+        <div class="wf-bar-wrap">
+          <div
+              class="wb wb--blocked wb--phase"
+              title="Blocked: 2 ms"
+              style="left:18.2491%;width:0.2466%"
+            ></div>
+              <div
+              class="wb wb--css-light"
+              title="Send+Wait: 19 ms"
+              style="left:18.4957%;width:2.3428%"
+            ></div>
+              <div
+              class="wb wb--css-dark"
+              title="Receive: 32 ms"
+              style="left:20.8385%;width:3.9457%"
+            ></div>
+          <span class="wf-bar-dur">53 ms</span>
+        </div>
+      </span>
+      </li>
+        <li
+        class="wf-row wf-row--rh26"
+        data-index="2"
+        data-started="2024-01-15T10:00:00.150Z"
+        data-time="80"
+        data-blocked="2"
+
+        data-dns="0"
+        data-connect="0"
+        data-ssl="0"
+        data-send="1"
+        data-wait="22"
+        data-receive="55"
+        data-body-size="12400"
+         data-transfer-size="8928"
+      >
+        <span class="wf-cell wf-cell--idx">3</span>
+        <span class="wf-cell wf-cell--url" title="https://example.com/assets/runtime.js"
+          ><span class="wf-url-domain">example.com</span><span class="wf-url-path">/assets/runtime.js</span></span
+        >
+        <span class="wf-cell wf-cell--info">GET</span>
+        <span class="wf-cell wf-cell--info">h2</span>
+        <span class="wf-cell wf-cell--info wf-cell--stat s2xx"
+          >200</span
+        >
+        <span class="wf-cell wf-cell--info">js</span>
+        <span class="wf-cell wf-cell--info wf-cell--size">8.7 KB</span>
+        <span class="wf-cell wf-cell--info wf-cell--dur">80 ms</span>
+        <span
+        class="wf-cell wf-cell--timeline"
+        style="--wf-bar-end:28.3600%"
+      >
+        <div class="wf-bar-wrap">
+          <div
+              class="wb wb--blocked wb--phase"
+              title="Blocked: 2 ms"
+              style="left:18.4957%;width:0.2466%"
+            ></div>
+              <div
+              class="wb wb--js-light"
+              title="Send+Wait: 23 ms"
+              style="left:18.7423%;width:2.8360%"
+            ></div>
+              <div
+              class="wb wb--js-dark"
+              title="Receive: 55 ms"
+              style="left:21.5783%;width:6.7818%"
+            ></div>
+          <span class="wf-bar-dur">80 ms</span>
+        </div>
+      </span>
+      </li>
+        <li
+        class="wf-row wf-row--rh26"
+        data-index="3"
+        data-started="2024-01-15T10:00:00.152Z"
+        data-time="208"
+        data-blocked="2"
+
+        data-dns="0"
+        data-connect="0"
+        data-ssl="0"
+        data-send="1"
+        data-wait="25"
+        data-receive="180"
+        data-body-size="68000"
+         data-transfer-size="48960"
+      >
+        <span class="wf-cell wf-cell--idx">4</span>
+        <span class="wf-cell wf-cell--url" title="https://example.com/assets/app.js"
+          ><span class="wf-url-domain">example.com</span><span class="wf-url-path">/assets/app.js</span></span
+        >
+        <span class="wf-cell wf-cell--info">GET</span>
+        <span class="wf-cell wf-cell--info">h2</span>
+        <span class="wf-cell wf-cell--info wf-cell--stat s2xx"
+          >200</span
+        >
+        <span class="wf-cell wf-cell--info">js</span>
+        <span class="wf-cell wf-cell--info wf-cell--size">47.8 KB</span>
+        <span class="wf-cell wf-cell--info wf-cell--dur">208 ms</span>
+        <span
+        class="wf-cell wf-cell--timeline"
+        style="--wf-bar-end:44.3896%"
+      >
+        <div class="wf-bar-wrap">
+          <div
+              class="wb wb--blocked wb--phase"
+              title="Blocked: 2 ms"
+              style="left:18.7423%;width:0.2466%"
+            ></div>
+              <div
+              class="wb wb--js-light"
+              title="Send+Wait: 26 ms"
+              style="left:18.9889%;width:3.2059%"
+            ></div>
+              <div
+              class="wb wb--js-dark"
+              title="Receive: 180 ms"
+              style="left:22.1948%;width:22.1948%"
+            ></div>
+          <span class="wf-bar-dur">208 ms</span>
+        </div>
+      </span>
+      </li>
+        <li
+        class="wf-row wf-row--rh26"
+        data-index="4"
+        data-started="2024-01-15T10:00:00.155Z"
+        data-time="159"
+        data-blocked="0"
+
+        data-dns="12"
+        data-connect="28"
+        data-ssl="18"
+        data-send="1"
+        data-wait="38"
+        data-receive="62"
+        data-body-size="22000"
+         data-transfer-size="15840"
+      >
+        <span class="wf-cell wf-cell--idx">5</span>
+        <span class="wf-cell wf-cell--url" title="https://fonts.example.com/inter-400.woff2"
+          ><span class="wf-url-domain">fonts.example.com</span><span class="wf-url-path">/inter-400.woff2</span></span
+        >
+        <span class="wf-cell wf-cell--info">GET</span>
+        <span class="wf-cell wf-cell--info">h2</span>
+        <span class="wf-cell wf-cell--info wf-cell--stat s2xx"
+          >200</span
+        >
+        <span class="wf-cell wf-cell--info">font</span>
+        <span class="wf-cell wf-cell--info wf-cell--size">15.5 KB</span>
+        <span class="wf-cell wf-cell--info wf-cell--dur">159 ms</span>
+        <span
+        class="wf-cell wf-cell--timeline"
+        style="--wf-bar-end:38.7176%"
+      >
+        <div class="wf-bar-wrap">
+          <div
+              class="wb wb--dns wb--phase"
+              title="DNS Lookup: 12 ms"
+              style="left:19.1122%;width:1.4797%"
+            ></div>
+              <div
+              class="wb wb--connect wb--phase"
+              title="TCP Connect: 28 ms"
+              style="left:20.5919%;width:3.4525%"
+            ></div>
+              <div
+              class="wb wb--ssl wb--phase"
+              title="TLS Handshake: 18 ms"
+              style="left:24.0444%;width:2.2195%"
+            ></div>
+              <div
+              class="wb wb--font-light"
+              title="Send+Wait: 39 ms"
+              style="left:26.2639%;width:4.8089%"
+            ></div>
+              <div
+              class="wb wb--font-dark"
+              title="Receive: 62 ms"
+              style="left:31.0727%;width:7.6449%"
+            ></div>
+          <span class="wf-bar-dur">159 ms</span>
+        </div>
+      </span>
+      </li>
+        <li
+        class="wf-row wf-row--rh26"
+        data-index="5"
+        data-started="2024-01-15T10:00:00.158Z"
+        data-time="157"
+        data-blocked="0"
+
+        data-dns="12"
+        data-connect="28"
+        data-ssl="18"
+        data-send="1"
+        data-wait="40"
+        data-receive="58"
+        data-body-size="19500"
+         data-transfer-size="14040"
+      >
+        <span class="wf-cell wf-cell--idx">6</span>
+        <span class="wf-cell wf-cell--url" title="https://fonts.example.com/inter-600.woff2"
+          ><span class="wf-url-domain">fonts.example.com</span><span class="wf-url-path">/inter-600.woff2</span></span
+        >
+        <span class="wf-cell wf-cell--info">GET</span>
+        <span class="wf-cell wf-cell--info">h2</span>
+        <span class="wf-cell wf-cell--info wf-cell--stat s2xx"
+          >200</span
+        >
+        <span class="wf-cell wf-cell--info">font</span>
+        <span class="wf-cell wf-cell--info wf-cell--size">13.7 KB</span>
+        <span class="wf-cell wf-cell--info wf-cell--dur">157 ms</span>
+        <span
+        class="wf-cell wf-cell--timeline"
+        style="--wf-bar-end:38.8409%"
+      >
+        <div class="wf-bar-wrap">
+          <div
+              class="wb wb--dns wb--phase"
+              title="DNS Lookup: 12 ms"
+              style="left:19.4821%;width:1.4797%"
+            ></div>
+              <div
+              class="wb wb--connect wb--phase"
+              title="TCP Connect: 28 ms"
+              style="left:20.9618%;width:3.4525%"
+            ></div>
+              <div
+              class="wb wb--ssl wb--phase"
+              title="TLS Handshake: 18 ms"
+              style="left:24.4143%;width:2.2195%"
+            ></div>
+              <div
+              class="wb wb--font-light"
+              title="Send+Wait: 41 ms"
+              style="left:26.6338%;width:5.0555%"
+            ></div>
+              <div
+              class="wb wb--font-dark"
+              title="Receive: 58 ms"
+              style="left:31.6893%;width:7.1517%"
+            ></div>
+          <span class="wf-bar-dur">157 ms</span>
+        </div>
+      </span>
+      </li>
+        <li
+        class="wf-row wf-row--rh26"
+        data-index="6"
+        data-started="2024-01-15T10:00:00.200Z"
+        data-time="410"
+        data-blocked="0"
+
+        data-dns="8"
+        data-connect="22"
+        data-ssl="14"
+        data-send="1"
+        data-wait="55"
+        data-receive="310"
+        data-body-size="95000"
+         data-transfer-size="68400"
+      >
+        <span class="wf-cell wf-cell--idx">7</span>
+        <span class="wf-cell wf-cell--url" title="https://cdn.example.com/hero.webp"
+          ><span class="wf-url-domain">cdn.example.com</span><span class="wf-url-path">/hero.webp</span></span
+        >
+        <span class="wf-cell wf-cell--info">GET</span>
+        <span class="wf-cell wf-cell--info">h2</span>
+        <span class="wf-cell wf-cell--info wf-cell--stat s2xx"
+          >200</span
+        >
+        <span class="wf-cell wf-cell--info">image</span>
+        <span class="wf-cell wf-cell--info wf-cell--size">66.8 KB</span>
+        <span class="wf-cell wf-cell--info wf-cell--dur">410 ms</span>
+        <span
+        class="wf-cell wf-cell--timeline"
+        style="--wf-bar-end:75.2158%"
+      >
+        <div class="wf-bar-wrap">
+          <div
+              class="wb wb--dns wb--phase"
+              title="DNS Lookup: 8 ms"
+              style="left:24.6609%;width:0.9864%"
+            ></div>
+              <div
+              class="wb wb--connect wb--phase"
+              title="TCP Connect: 22 ms"
+              style="left:25.6473%;width:2.7127%"
+            ></div>
+              <div
+              class="wb wb--ssl wb--phase"
+              title="TLS Handshake: 14 ms"
+              style="left:28.3600%;width:1.7263%"
+            ></div>
+              <div
+              class="wb wb--image-light"
+              title="Send+Wait: 56 ms"
+              style="left:30.0863%;width:6.9051%"
+            ></div>
+              <div
+              class="wb wb--image-dark"
+              title="Receive: 310 ms"
+              style="left:36.9914%;width:38.2244%"
+            ></div>
+          <span class="wf-bar-dur">410 ms</span>
+        </div>
+      </span>
+      </li>
+        <li
+        class="wf-row wf-row--rh26"
+        data-index="7"
+        data-started="2024-01-15T10:00:00.205Z"
+        data-time="31"
+        data-blocked="0"
+
+        data-dns="0"
+        data-connect="0"
+        data-ssl="0"
+        data-send="1"
+        data-wait="12"
+        data-receive="18"
+        data-body-size="2100"
+         data-transfer-size="1512"
+      >
+        <span class="wf-cell wf-cell--idx">8</span>
+        <span class="wf-cell wf-cell--url" title="https://cdn.example.com/logo.svg"
+          ><span class="wf-url-domain">cdn.example.com</span><span class="wf-url-path">/logo.svg</span></span
+        >
+        <span class="wf-cell wf-cell--info">GET</span>
+        <span class="wf-cell wf-cell--info">h2</span>
+        <span class="wf-cell wf-cell--info wf-cell--stat s2xx"
+          >200</span
+        >
+        <span class="wf-cell wf-cell--info">image</span>
+        <span class="wf-cell wf-cell--info wf-cell--size">1.5 KB</span>
+        <span class="wf-cell wf-cell--info wf-cell--dur">31 ms</span>
+        <span
+        class="wf-cell wf-cell--timeline"
+        style="--wf-bar-end:29.0999%"
+      >
+        <div class="wf-bar-wrap">
+          <div
+              class="wb wb--image-light"
+              title="Send+Wait: 13 ms"
+              style="left:25.2774%;width:1.6030%"
+            ></div>
+              <div
+              class="wb wb--image-dark"
+              title="Receive: 18 ms"
+              style="left:26.8804%;width:2.2195%"
+            ></div>
+          <span class="wf-bar-dur">31 ms</span>
+        </div>
+      </span>
+      </li>
+        <li
+        class="wf-row wf-row--rh26 row--blocking"
+        data-index="8"
+        data-started="2024-01-15T10:00:00.360Z"
+        data-time="299"
+        data-blocked="130"
+
+        data-dns="18"
+        data-connect="38"
+        data-ssl="22"
+        data-send="1"
+        data-wait="62"
+        data-receive="28"
+        data-body-size="5200"
+         data-transfer-size="3744"
+      >
+        <span class="wf-cell wf-cell--idx">9</span>
+        <span class="wf-cell wf-cell--url" title="https://analytics.example.com/pixel.js"
+          ><span class="wf-url-domain">analytics.example.com</span><span class="wf-url-path">/pixel.js</span></span
+        >
+        <span class="wf-cell wf-cell--info">GET</span>
+        <span class="wf-cell wf-cell--info">h2</span>
+        <span class="wf-cell wf-cell--info wf-cell--stat s2xx"
+          >200</span
+        >
+        <span class="wf-cell wf-cell--info">js</span>
+        <span class="wf-cell wf-cell--info wf-cell--size">3.7 KB</span>
+        <span class="wf-cell wf-cell--info wf-cell--dur">299 ms</span>
+        <span
+        class="wf-cell wf-cell--timeline"
+        style="--wf-bar-end:81.2577%"
+      >
+        <div class="wf-bar-wrap">
+          <div
+              class="wb wb--blocked wb--phase"
+              title="Blocked: 130 ms"
+              style="left:44.3896%;width:16.0296%"
+            ></div>
+              <div
+              class="wb wb--dns wb--phase"
+              title="DNS Lookup: 18 ms"
+              style="left:60.4192%;width:2.2195%"
+            ></div>
+              <div
+              class="wb wb--connect wb--phase"
+              title="TCP Connect: 38 ms"
+              style="left:62.6387%;width:4.6856%"
+            ></div>
+              <div
+              class="wb wb--ssl wb--phase"
+              title="TLS Handshake: 22 ms"
+              style="left:67.3243%;width:2.7127%"
+            ></div>
+              <div
+              class="wb wb--js-light"
+              title="Send+Wait: 63 ms"
+              style="left:70.0370%;width:7.7682%"
+            ></div>
+              <div
+              class="wb wb--js-dark"
+              title="Receive: 28 ms"
+              style="left:77.8052%;width:3.4525%"
+            ></div>
+          <span class="wf-bar-dur">299 ms</span>
+        </div>
+      </span>
+      </li>
+        <li
+        class="wf-row wf-row--rh26 row--blocking"
+        data-index="9"
+        data-started="2024-01-15T10:00:00.362Z"
+        data-time="449"
+        data-blocked="125"
+
+        data-dns="22"
+        data-connect="42"
+        data-ssl="26"
+        data-send="1"
+        data-wait="88"
+        data-receive="145"
+        data-body-size="38000"
+         data-transfer-size="27360"
+      >
+        <span class="wf-cell wf-cell--idx">10</span>
+        <span class="wf-cell wf-cell--url" title="https://cdn.thirdparty.com/widget.js"
+          ><span class="wf-url-domain">cdn.thirdparty.com</span><span class="wf-url-path">/widget.js</span></span
+        >
+        <span class="wf-cell wf-cell--info">GET</span>
+        <span class="wf-cell wf-cell--info">h2</span>
+        <span class="wf-cell wf-cell--info wf-cell--stat s2xx"
+          >200</span
+        >
+        <span class="wf-cell wf-cell--info">js</span>
+        <span class="wf-cell wf-cell--info wf-cell--size">26.7 KB</span>
+        <span class="wf-cell wf-cell--info wf-cell--dur">449 ms</span>
+        <span
+        class="wf-cell wf-cell--timeline"
+        style="--wf-bar-end:100.0000%"
+      >
+        <div class="wf-bar-wrap">
+          <div
+              class="wb wb--blocked wb--phase"
+              title="Blocked: 125 ms"
+              style="left:44.6363%;width:15.4131%"
+            ></div>
+              <div
+              class="wb wb--dns wb--phase"
+              title="DNS Lookup: 22 ms"
+              style="left:60.0493%;width:2.7127%"
+            ></div>
+              <div
+              class="wb wb--connect wb--phase"
+              title="TCP Connect: 42 ms"
+              style="left:62.7620%;width:5.1788%"
+            ></div>
+              <div
+              class="wb wb--ssl wb--phase"
+              title="TLS Handshake: 26 ms"
+              style="left:67.9408%;width:3.2059%"
+            ></div>
+              <div
+              class="wb wb--js-light"
+              title="Send+Wait: 89 ms"
+              style="left:71.1467%;width:10.9741%"
+            ></div>
+              <div
+              class="wb wb--js-dark"
+              title="Receive: 145 ms"
+              style="left:82.1208%;width:17.8792%"
+            ></div>
+          <span class="wf-bar-dur">449 ms</span>
+        </div>
+      </span>
+      </li>
+        <li
+        class="wf-row wf-row--rh26"
+        data-index="10"
+        data-started="2024-01-15T10:00:00.390Z"
+        data-time="114"
+        data-blocked="0"
+
+        data-dns="0"
+        data-connect="0"
+        data-ssl="0"
+        data-send="1"
+        data-wait="18"
+        data-receive="95"
+        data-body-size="28000"
+         data-transfer-size="20160"
+      >
+        <span class="wf-cell wf-cell--idx">11</span>
+        <span class="wf-cell wf-cell--url" title="https://cdn.example.com/thumbnail-1.webp"
+          ><span class="wf-url-domain">cdn.example.com</span><span class="wf-url-path">/thumbnail-1.webp</span></span
+        >
+        <span class="wf-cell wf-cell--info">GET</span>
+        <span class="wf-cell wf-cell--info">h2</span>
+        <span class="wf-cell wf-cell--info wf-cell--stat s2xx"
+          >200</span
+        >
+        <span class="wf-cell wf-cell--info">image</span>
+        <span class="wf-cell wf-cell--info wf-cell--size">19.7 KB</span>
+        <span class="wf-cell wf-cell--info wf-cell--dur">114 ms</span>
+        <span
+        class="wf-cell wf-cell--timeline"
+        style="--wf-bar-end:62.1455%"
+      >
+        <div class="wf-bar-wrap">
+          <div
+              class="wb wb--image-light"
+              title="Send+Wait: 19 ms"
+              style="left:48.0888%;width:2.3428%"
+            ></div>
+              <div
+              class="wb wb--image-dark"
+              title="Receive: 95 ms"
+              style="left:50.4316%;width:11.7139%"
+            ></div>
+          <span class="wf-bar-dur">114 ms</span>
+        </div>
+      </span>
+      </li>
+        <li
+        class="wf-row wf-row--rh26"
+        data-index="11"
+        data-started="2024-01-15T10:00:00.392Z"
+        data-time="123"
+        data-blocked="0"
+
+        data-dns="0"
+        data-connect="0"
+        data-ssl="0"
+        data-send="1"
+        data-wait="20"
+        data-receive="102"
+        data-body-size="31000"
+         data-transfer-size="22320"
+      >
+        <span class="wf-cell wf-cell--idx">12</span>
+        <span class="wf-cell wf-cell--url" title="https://cdn.example.com/thumbnail-2.webp"
+          ><span class="wf-url-domain">cdn.example.com</span><span class="wf-url-path">/thumbnail-2.webp</span></span
+        >
+        <span class="wf-cell wf-cell--info">GET</span>
+        <span class="wf-cell wf-cell--info">h2</span>
+        <span class="wf-cell wf-cell--info wf-cell--stat s2xx"
+          >200</span
+        >
+        <span class="wf-cell wf-cell--info">image</span>
+        <span class="wf-cell wf-cell--info wf-cell--size">21.8 KB</span>
+        <span class="wf-cell wf-cell--info wf-cell--dur">123 ms</span>
+        <span
+        class="wf-cell wf-cell--timeline"
+        style="--wf-bar-end:63.5018%"
+      >
+        <div class="wf-bar-wrap">
+          <div
+              class="wb wb--image-light"
+              title="Send+Wait: 21 ms"
+              style="left:48.3354%;width:2.5894%"
+            ></div>
+              <div
+              class="wb wb--image-dark"
+              title="Receive: 102 ms"
+              style="left:50.9248%;width:12.5771%"
+            ></div>
+          <span class="wf-bar-dur">123 ms</span>
+        </div>
+      </span>
+      </li>
+        <li
+        class="wf-row wf-row--rh26"
+        data-index="12"
+        data-started="2024-01-15T10:00:00.395Z"
+        data-time="111"
+        data-blocked="0"
+
+        data-dns="0"
+        data-connect="0"
+        data-ssl="0"
+        data-send="1"
+        data-wait="22"
+        data-receive="88"
+        data-body-size="24500"
+         data-transfer-size="17640"
+      >
+        <span class="wf-cell wf-cell--idx">13</span>
+        <span class="wf-cell wf-cell--url" title="https://cdn.example.com/thumbnail-3.webp"
+          ><span class="wf-url-domain">cdn.example.com</span><span class="wf-url-path">/thumbnail-3.webp</span></span
+        >
+        <span class="wf-cell wf-cell--info">GET</span>
+        <span class="wf-cell wf-cell--info">h2</span>
+        <span class="wf-cell wf-cell--info wf-cell--stat s2xx"
+          >200</span
+        >
+        <span class="wf-cell wf-cell--info">image</span>
+        <span class="wf-cell wf-cell--info wf-cell--size">17.2 KB</span>
+        <span class="wf-cell wf-cell--info wf-cell--dur">111 ms</span>
+        <span
+        class="wf-cell wf-cell--timeline"
+        style="--wf-bar-end:62.3921%"
+      >
+        <div class="wf-bar-wrap">
+          <div
+              class="wb wb--image-light"
+              title="Send+Wait: 23 ms"
+              style="left:48.7053%;width:2.8360%"
+            ></div>
+              <div
+              class="wb wb--image-dark"
+              title="Receive: 88 ms"
+              style="left:51.5413%;width:10.8508%"
+            ></div>
+          <span class="wf-bar-dur">111 ms</span>
+        </div>
+      </span>
+      </li>
+        <li
+        class="wf-row wf-row--rh26"
+        data-index="13"
+        data-started="2024-01-15T10:00:00.420Z"
+        data-time="108"
+        data-blocked="0"
+
+        data-dns="10"
+        data-connect="24"
+        data-ssl="16"
+        data-send="1"
+        data-wait="45"
+        data-receive="12"
+        data-body-size="1800"
+         data-transfer-size="1296"
+      >
+        <span class="wf-cell wf-cell--idx">14</span>
+        <span class="wf-cell wf-cell--url" title="https://api.example.com/v1/config"
+          ><span class="wf-url-domain">api.example.com</span><span class="wf-url-path">/v1/config</span></span
+        >
+        <span class="wf-cell wf-cell--info">GET</span>
+        <span class="wf-cell wf-cell--info">h2</span>
+        <span class="wf-cell wf-cell--info wf-cell--stat s2xx"
+          >200</span
+        >
+        <span class="wf-cell wf-cell--info">other</span>
+        <span class="wf-cell wf-cell--info wf-cell--size">1.3 KB</span>
+        <span class="wf-cell wf-cell--info wf-cell--dur">108 ms</span>
+        <span
+        class="wf-cell wf-cell--timeline"
+        style="--wf-bar-end:65.1048%"
+      >
+        <div class="wf-bar-wrap">
+          <div
+              class="wb wb--dns wb--phase"
+              title="DNS Lookup: 10 ms"
+              style="left:51.7879%;width:1.2330%"
+            ></div>
+              <div
+              class="wb wb--connect wb--phase"
+              title="TCP Connect: 24 ms"
+              style="left:53.0210%;width:2.9593%"
+            ></div>
+              <div
+              class="wb wb--ssl wb--phase"
+              title="TLS Handshake: 16 ms"
+              style="left:55.9803%;width:1.9729%"
+            ></div>
+              <div
+              class="wb wb--other-light"
+              title="Send+Wait: 46 ms"
+              style="left:57.9531%;width:5.6720%"
+            ></div>
+              <div
+              class="wb wb--other-dark"
+              title="Receive: 12 ms"
+              style="left:63.6252%;width:1.4797%"
+            ></div>
+          <span class="wf-bar-dur">108 ms</span>
+        </div>
+      </span>
+      </li>
+        <li
+        class="wf-row wf-row--rh26"
+        data-index="14"
+        data-started="2024-01-15T10:00:00.440Z"
+        data-time="182"
+        data-blocked="0"
+
+        data-dns="0"
+        data-connect="0"
+        data-ssl="0"
+        data-send="2"
+        data-wait="142"
+        data-receive="38"
+        data-body-size="6400"
+         data-transfer-size="4608"
+      >
+        <span class="wf-cell wf-cell--idx">15</span>
+        <span class="wf-cell wf-cell--url" title="https://api.example.com/v1/recommendations"
+          ><span class="wf-url-domain">api.example.com</span><span class="wf-url-path">/v1/recommendations</span></span
+        >
+        <span class="wf-cell wf-cell--info">GET</span>
+        <span class="wf-cell wf-cell--info">h2</span>
+        <span class="wf-cell wf-cell--info wf-cell--stat s2xx"
+          >200</span
+        >
+        <span class="wf-cell wf-cell--info">other</span>
+        <span class="wf-cell wf-cell--info wf-cell--size">4.5 KB</span>
+        <span class="wf-cell wf-cell--info wf-cell--dur">182 ms</span>
+        <span
+        class="wf-cell wf-cell--timeline"
+        style="--wf-bar-end:76.6954%"
+      >
+        <div class="wf-bar-wrap">
+          <div
+              class="wb wb--other-light"
+              title="Send+Wait: 144 ms"
+              style="left:54.2540%;width:17.7559%"
+            ></div>
+              <div
+              class="wb wb--other-dark"
+              title="Receive: 38 ms"
+              style="left:72.0099%;width:4.6856%"
+            ></div>
+          <span class="wf-bar-dur">182 ms</span>
+        </div>
+      </span>
+      </li>
+            </ol>
+          </div>
+
+          <p class="wf-message wf-loading" aria-live="polite" hidden>
+            Loading waterfall…
+          </p>
+          <p class="wf-message wf-message--error wf-error" hidden></p>
+    <!-- wf-demo-end -->
     </waterfall-chart>
   </body>
 </html>

--- a/packages/waterfall/public/progressive.js
+++ b/packages/waterfall/public/progressive.js
@@ -7,9 +7,12 @@ btn.addEventListener(
     btn.disabled = true;
     status.textContent = 'Loading…';
 
+    const inert = document.querySelector(`script[type="application/wf-lazy"]`);
+    const src = inert ? inert.getAttribute('src') : '/waterfall/waterfall.js';
+
     const s = document.createElement('script');
     s.type = 'module';
-    s.src = '/waterfall/waterfall.js';
+    s.src = src;
     s.addEventListener('load', function () {
       status.textContent =
         '✓ Web component active — filters and row details now work.';

--- a/packages/waterfall/public/src-attr.html
+++ b/packages/waterfall/public/src-attr.html
@@ -22,18 +22,42 @@
           <li><a href="src-attr.html" aria-current="page">src attribute</a></li>
         </ul>
       </nav>
-      <label
-        class="theme-toggle"
-        aria-label="Toggle colour theme"
-        title="Toggle colour theme"
-      >
-        <span class="theme-toggle__icon">☀️</span>
-        <input type="checkbox" id="theme-btn" />
-        <span class="theme-toggle__track"
-          ><span class="theme-toggle__knob"></span
-        ></span>
-        <span class="theme-toggle__icon">🌙</span>
-      </label>
+      <div class="header-actions">
+        <a
+          class="github-link"
+          href="https://github.com/cloudflare/telescope/tree/main/packages/waterfall#readme"
+          target="_blank"
+          rel="noopener noreferrer"
+          aria-label="View on GitHub"
+          title="View on GitHub"
+        >
+          <svg
+            class="github-link__icon"
+            xmlns="http://www.w3.org/2000/svg"
+            viewBox="0 0 24 24"
+            width="20"
+            height="20"
+            aria-hidden="true"
+          >
+            <path
+              fill="currentColor"
+              d="M12 .5C5.73.5.5 5.74.5 12.02c0 5.08 3.29 9.39 7.86 10.91.58.11.79-.25.79-.56 0-.28-.01-1.02-.02-2-3.2.7-3.87-1.54-3.87-1.54-.52-1.33-1.28-1.68-1.28-1.68-1.04-.71.08-.7.08-.7 1.16.08 1.77 1.19 1.77 1.19 1.03 1.76 2.7 1.25 3.36.96.1-.75.4-1.25.73-1.54-2.55-.29-5.24-1.28-5.24-5.69 0-1.26.45-2.29 1.18-3.09-.12-.29-.51-1.46.11-3.05 0 0 .97-.31 3.18 1.18a11 11 0 0 1 2.9-.39c.98 0 1.97.13 2.9.39 2.2-1.49 3.17-1.18 3.17-1.18.63 1.59.24 2.76.12 3.05.74.8 1.18 1.83 1.18 3.09 0 4.42-2.69 5.39-5.26 5.68.41.35.77 1.05.77 2.11 0 1.53-.01 2.76-.01 3.13 0 .31.21.68.8.56 4.56-1.53 7.85-5.83 7.85-10.91C23.5 5.74 18.27.5 12 .5z"
+            />
+          </svg>
+        </a>
+        <label
+          class="theme-toggle"
+          aria-label="Toggle colour theme"
+          title="Toggle colour theme"
+        >
+          <span class="theme-toggle__icon">☀️</span>
+          <input type="checkbox" id="theme-btn" />
+          <span class="theme-toggle__track"
+            ><span class="theme-toggle__knob"></span
+          ></span>
+          <span class="theme-toggle__icon">🌙</span>
+        </label>
+      </div>
     </header>
 
     <h1>src attribute</h1>

--- a/packages/waterfall/vite.config.ts
+++ b/packages/waterfall/vite.config.ts
@@ -86,4 +86,13 @@ export default defineConfig({
       },
     },
   },
+
+  // Demo-only static assets (theme.js, progressive.js, interactive.js,
+  // demo.css, demo.har) live alongside the entry HTML in `public/`. They
+  // are referenced from the HTML via absolute paths (e.g. `/theme.js`),
+  // which Vite does not rewrite as build inputs, so we mark the same
+  // directory as `publicDir` to have Vite copy them verbatim into
+  // `dist-demo/`. Setting `publicDir` equal to `root` is supported; Vite
+  // just excludes files listed as HTML entry inputs from the copy.
+  publicDir: resolve(__dirname, 'public'),
 });

--- a/packages/waterfall/vite.config.ts
+++ b/packages/waterfall/vite.config.ts
@@ -59,6 +59,24 @@ function srcAliasPlugin(): Plugin {
   };
 }
 
+function lazyModulePlugin(): Plugin {
+  return {
+    name: 'lazy-module',
+    apply: 'build',
+    transformIndexHtml: {
+      order: 'post',
+      handler(html, ctx) {
+        if (!ctx.filename.endsWith('index.html')) return html;
+        const chunk = Object.values(ctx.bundle ?? {}).find(
+          (c) => c.type === 'chunk' && c.name === 'waterfall',
+        );
+        if (!chunk) return html;
+        return html.replace('/waterfall/waterfall.js', '/' + chunk.fileName);
+      },
+    },
+  };
+}
+
 export default defineConfig({
   // Serve public/ as the web root: index.html lives at /
   root: resolve(__dirname, 'public'),
@@ -73,7 +91,7 @@ export default defineConfig({
     },
   },
 
-  plugins: [srcAliasPlugin()],
+  plugins: [srcAliasPlugin(), lazyModulePlugin()],
 
   build: {
     outDir: resolve(__dirname, 'dist-demo'),

--- a/packages/waterfall/wrangler.jsonc
+++ b/packages/waterfall/wrangler.jsonc
@@ -1,0 +1,15 @@
+{
+  "$schema": "node_modules/wrangler/config-schema.json",
+  "name": "waterfall-telescopetest-io-demo-site",
+  "compatibility_date": "2026-07-10",
+  "account_id": "4b1c95badf17540db82cd8b431ae3eb0",
+  "routes": [
+    {
+      "pattern": "waterfall.telescopetest.io",
+      "custom_domain": true,
+    },
+  ],
+  "assets": {
+    "directory": "./dist-demo",
+  },
+}


### PR DESCRIPTION
Closes #275.

Deploys the `@cloudflare/waterfall` demo site to `waterfall.telescopetest.io` and polishes the demo pages.

## Deployment

- **`packages/waterfall/wrangler.jsonc`** — new Worker config that routes `waterfall.telescopetest.io` and serves `dist-demo/` as static assets.
- **`.github/workflows/deploy-waterfall-site.yml`** — new workflow that runs on any push to `main` touching `packages/waterfall/**`, builds the demo, and deploys via `wrangler deploy`. Mirrors the existing `deploy.yml` (for `telescope-web`) pattern.

## Build fixes

- **`packages/waterfall/package.json`** — `build:demo` now runs `npm run build` first, because `gen-demo` imports `renderToHTML` from `dist/`; `clean` also removes `dist-demo/`.
- **`packages/waterfall/vite.config.ts`** — sets `publicDir` to `public/` (same as `root`) so demo-only static assets (`theme.js`, `progressive.js`, `interactive.js`, `demo.css`, `demo.har`) are copied verbatim into `dist-demo/`. Without this, Vite's default `publicDir` resolved to `public/public/` (nonexistent), leaving those files out of the build and breaking the deployed pages.

## Demo page polish (per issue #275)

- **`packages/waterfall/public/{index,interactive,src-attr}.html`** + **`demo.css`** — add a GitHub link icon in each demo page header (next to the theme toggle) pointing at the repo's waterfall README. Styles cover both `prefers-color-scheme: dark` and the explicit `[data-theme="dark"]` override.
- **`packages/waterfall/README.md`** — add a "Live demo" link at the top pointing to `waterfall.telescopetest.io`.

## Verifying locally

```bash
npm run build:demo -w packages/waterfall
ls packages/waterfall/dist-demo   # should include theme.js, progressive.js, interactive.js, demo.css, demo.har
npx wrangler dev -c packages/waterfall/wrangler.jsonc
```

## Notes

- First-time secrets: this workflow needs `CLOUDFLARE_API_TOKEN` (already used by `deploy.yml`), and the `waterfall.telescopetest.io` DNS record must exist and point at the Worker's route.
- The workflow is guarded by `if: github.repository == 'cloudflare/telescope'` so forks are a no-op.