### PR TITLE
Add chromium to list of packages, release new npm package

### DIFF
--- a/.changeset/tender-aliens-divide.md
+++ b/.changeset/tender-aliens-divide.md
@@ -1,0 +1,5 @@
+---
+"@cloudflare/telescope": minor
+---
+
+Fetch priority support, added chromium to browser options.

--- a/package-lock.json
+++ b/package-lock.json
@@ -4662,9 +4662,9 @@
             "license": "MIT"
         },
         "node_modules/astro": {
-            "version": "6.4.6",
-            "resolved": "https://registry.npmjs.org/astro/-/astro-6.4.6.tgz",
-            "integrity": "sha512-48OBTBKR9ctbf+DQxpOuxGl8ebfn59zTuNQMBzptmG/Mi/H8IdfMSbJgGuX1I/4U6g9yazG1p4BHlf4+2hWU4Q==",
+            "version": "6.4.8",
+            "resolved": "https://registry.npmjs.org/astro/-/astro-6.4.8.tgz",
+            "integrity": "sha512-KK5lX90uU9EeVaTjINyj3sy9/NFXVa59aowaqbWBDDKLXZh4rr7GwIaCFYVetE22MJtsCNFerQXn0vlCLmpP/Q==",
             "license": "MIT",
             "dependencies": {
                 "@astrojs/compiler": "^4.0.0",
@@ -11794,7 +11794,7 @@
                 "@prisma/adapter-d1": "^7.5.0",
                 "@prisma/client": "^7.5.0",
                 "@vitest/coverage-v8": "^4.1.8",
-                "astro": "^6.4.6",
+                "astro": "^6.4.8",
                 "fflate": "^0.8.2",
                 "react": "^19.2.4",
                 "react-dom": "^19.2.4",

--- a/packages/telescope/src/index.ts
+++ b/packages/telescope/src/index.ts
@@ -258,6 +258,7 @@ export default function browserAgent(): void {
         'chrome-beta',
         'canary',
         'edge',
+        'chromium',
         'safari',
         'firefox',
       ]),


### PR DESCRIPTION
Close #309 

Also updated `package-lock.json` that got out-of-sync after dependabot upgraded astro.