### PR TITLE
Extract external CSS stylesheets from HAR for Baseline feature detection

### DIFF
--- a/packages/telescope/__tests__/baselineCssExtract.test.ts
+++ b/packages/telescope/__tests__/baselineCssExtract.test.ts
@@ -1,0 +1,100 @@
+import { describe, it, expect } from 'vitest';
+
+import { extractCSSFromHar } from '../src/baselineCssExtract.js';
+import type { HarData, HarEntry } from '../src/types.js';
+
+// Build a minimal HAR entry in-memory (only the fields the extractor reads).
+function makeEntry(
+  url: string,
+  mimeType: string,
+  text: string | undefined,
+  encoding?: string,
+): HarEntry {
+  return {
+    request: { url, method: 'GET', headers: [] },
+    response: {
+      status: 200,
+      content: { size: text?.length ?? 0, mimeType, text, encoding },
+    },
+    time: 0,
+    startedDateTime: '1970-01-01T00:00:00.000Z',
+  };
+}
+
+function makeHar(entries: HarEntry[]): HarData {
+  return {
+    log: { pages: [], entries, browser: { name: 'test', version: '0' } },
+  };
+}
+
+const toBase64 = (value: string) =>
+  Buffer.from(value, 'utf8').toString('base64');
+
+describe('extractCSSFromHar — external stylesheets', () => {
+  it('extracts a text/css response as one source with the URL as file', () => {
+    const har = makeHar([
+      makeEntry('https://x.test/a.css', 'text/css', '.a { color: red; }'),
+    ]);
+
+    expect(extractCSSFromHar(har)).toEqual([
+      { css: '.a { color: red; }', file: 'https://x.test/a.css' },
+    ]);
+  });
+
+  it('matches text/css even with a charset parameter', () => {
+    const har = makeHar([
+      makeEntry('https://x.test/a.css', 'text/css; charset=utf-8', '.a {}'),
+    ]);
+
+    expect(extractCSSFromHar(har)).toHaveLength(1);
+  });
+
+  it('decodes base64-encoded CSS bodies', () => {
+    const css = '.a { color: blue; }';
+    const har = makeHar([
+      makeEntry('https://x.test/a.css', 'text/css', toBase64(css), 'base64'),
+    ]);
+
+    expect(extractCSSFromHar(har)[0].css).toBe(css);
+  });
+
+  it('preserves entry order across multiple stylesheets', () => {
+    const har = makeHar([
+      makeEntry('https://x.test/1.css', 'text/css', '.one {}'),
+      makeEntry('https://x.test/2.css', 'text/css', '.two {}'),
+    ]);
+
+    expect(extractCSSFromHar(har).map(source => source.file)).toEqual([
+      'https://x.test/1.css',
+      'https://x.test/2.css',
+    ]);
+  });
+});
+
+describe('extractCSSFromHar — ignored and edge cases', () => {
+  it('returns an empty array when there are no entries', () => {
+    expect(extractCSSFromHar(makeHar([]))).toEqual([]);
+  });
+
+  it('ignores entries with no response body text', () => {
+    const har = makeHar([
+      makeEntry('https://x.test/a.css', 'text/css', undefined),
+    ]);
+
+    expect(extractCSSFromHar(har)).toEqual([]);
+  });
+
+  it('ignores non-CSS resources', () => {
+    const har = makeHar([
+      makeEntry('https://x.test/img.png', 'image/png', 'notcss'),
+      makeEntry(
+        'https://x.test/app.js',
+        'application/javascript',
+        'const a = 1;',
+      ),
+      makeEntry('https://x.test/', 'text/html', '<html></html>'),
+    ]);
+
+    expect(extractCSSFromHar(har)).toEqual([]);
+  });
+});

--- a/packages/telescope/__tests__/baselineCssExtract.test.ts
+++ b/packages/telescope/__tests__/baselineCssExtract.test.ts
@@ -1,14 +1,15 @@
 import { describe, it, expect } from 'vitest';
 
 import { extractCSSFromHar } from '../src/baselineCssExtract.js';
-import type { HarData, HarEntry } from '../src/types.js';
+import { BASE64 } from '../src/types.js';
+import type { HarData, HarEntry, HARContentEncoding } from '../src/types.js';
 
 // Build a minimal HAR entry in-memory (only the fields the extractor reads).
 function makeEntry(
   url: string,
   mimeType: string,
   text: string | undefined,
-  encoding?: string,
+  encoding?: HARContentEncoding,
 ): HarEntry {
   return {
     request: { url, method: 'GET', headers: [] },
@@ -27,8 +28,7 @@ function makeHar(entries: HarEntry[]): HarData {
   };
 }
 
-const toBase64 = (value: string) =>
-  Buffer.from(value, 'utf8').toString('base64');
+const toBase64 = (value: string) => Buffer.from(value, 'utf8').toString(BASE64);
 
 describe('extractCSSFromHar — external stylesheets', () => {
   it('extracts a text/css response as one source with the URL as file', () => {
@@ -52,7 +52,7 @@ describe('extractCSSFromHar — external stylesheets', () => {
   it('decodes base64-encoded CSS bodies', () => {
     const css = '.a { color: blue; }';
     const har = makeHar([
-      makeEntry('https://x.test/a.css', 'text/css', toBase64(css), 'base64'),
+      makeEntry('https://x.test/a.css', 'text/css', toBase64(css), BASE64),
     ]);
 
     expect(extractCSSFromHar(har)[0].css).toBe(css);

--- a/packages/telescope/src/baselineCssExtract.ts
+++ b/packages/telescope/src/baselineCssExtract.ts
@@ -18,7 +18,7 @@ export function extractCSSFromHar(harData: HarData): CSSSource[] {
     const { text, encoding, mimeType } = entry.response.content;
     if (!text) continue;
 
-    if (mimeType.includes('text/css')) {
+    if (mimeType.toLowerCase().startsWith('text/css')) {
       sources.push({
         css: decodeContent(text, encoding),
         file: entry.request.url,

--- a/packages/telescope/src/baselineCssExtract.ts
+++ b/packages/telescope/src/baselineCssExtract.ts
@@ -36,7 +36,7 @@ export function extractCSSFromHar(harData: HarData): CSSSource[] {
  * @param encoding - The `content.encoding` value, if present.
  * @returns The decoded body as UTF-8 text.
  */
-function decodeContent(text: string, encoding?: string): string {
+function decodeContent(text: string, encoding?: 'base64'): string {
   if (encoding === 'base64') {
     return Buffer.from(text, 'base64').toString('utf8');
   }

--- a/packages/telescope/src/baselineCssExtract.ts
+++ b/packages/telescope/src/baselineCssExtract.ts
@@ -1,0 +1,44 @@
+import type { CSSSource, HarData } from './types.js';
+
+/**
+ * Extract external stylesheets (`text/css` responses) shipped by a page from
+ * its HAR.
+ *
+ * Inline `<style>` blocks in HTML documents are handled separately, in a
+ * follow-up change that parses the HTML with a dedicated parser.
+ *
+ * @param harData - Parsed HAR file contents.
+ * @returns One {@link CSSSource} per stylesheet, in the order they appear in
+ *   the HAR. Entries without a response body are skipped.
+ */
+export function extractCSSFromHar(harData: HarData): CSSSource[] {
+  const sources: CSSSource[] = [];
+
+  for (const entry of harData.log.entries) {
+    const { text, encoding, mimeType } = entry.response.content;
+    if (!text) continue;
+
+    if (mimeType.includes('text/css')) {
+      sources.push({
+        css: decodeContent(text, encoding),
+        file: entry.request.url,
+      });
+    }
+  }
+
+  return sources;
+}
+
+/**
+ * Decode a HAR response body, handling base64-encoded content.
+ *
+ * @param text - The raw `content.text` value from a HAR entry.
+ * @param encoding - The `content.encoding` value, if present.
+ * @returns The decoded body as UTF-8 text.
+ */
+function decodeContent(text: string, encoding?: string): string {
+  if (encoding === 'base64') {
+    return Buffer.from(text, 'base64').toString('utf8');
+  }
+  return text;
+}

--- a/packages/telescope/src/baselineCssExtract.ts
+++ b/packages/telescope/src/baselineCssExtract.ts
@@ -1,4 +1,5 @@
-import type { CSSSource, HarData } from './types.js';
+import { BASE64 } from './types.js';
+import type { CSSSource, HarData, HARContentEncoding } from './types.js';
 
 /**
  * Extract external stylesheets (`text/css` responses) shipped by a page from
@@ -36,9 +37,9 @@ export function extractCSSFromHar(harData: HarData): CSSSource[] {
  * @param encoding - The `content.encoding` value, if present.
  * @returns The decoded body as UTF-8 text.
  */
-function decodeContent(text: string, encoding?: 'base64'): string {
-  if (encoding === 'base64') {
-    return Buffer.from(text, 'base64').toString('utf8');
+function decodeContent(text: string, encoding: HARContentEncoding): string {
+  if (encoding === BASE64) {
+    return Buffer.from(text, BASE64).toString('utf8');
   }
   return text;
 }

--- a/packages/telescope/src/types.ts
+++ b/packages/telescope/src/types.ts
@@ -571,6 +571,8 @@ export interface HarEntry {
     content: {
       size: number;
       mimeType: string;
+      text?: string;
+      encoding?: string;
     };
   };
   time: number;
@@ -624,6 +626,18 @@ export interface HarLog {
  */
 export interface HarData {
   log: HarLog;
+}
+
+// ============================================================================
+// Baseline Types
+// ============================================================================
+
+/**
+ * A block of CSS extracted from a HAR, with its origin location.
+ */
+export interface CSSSource {
+  css: string;
+  file: string;
 }
 
 // ============================================================================

--- a/packages/telescope/src/types.ts
+++ b/packages/telescope/src/types.ts
@@ -572,7 +572,7 @@ export interface HarEntry {
       size: number;
       mimeType: string;
       text?: string;
-      encoding?: string;
+      encoding?: 'base64';
     };
   };
   time: number;

--- a/packages/telescope/src/types.ts
+++ b/packages/telescope/src/types.ts
@@ -557,6 +557,17 @@ export interface HTTPHeader {
 }
 
 /**
+ * The only content encoding Telescope decodes from a HAR response body.
+ */
+export const BASE64 = 'base64';
+
+/**
+ * Allowed values for a HAR entry's `content.encoding` field. `undefined`
+ * indicates the body is already plain text.
+ */
+export type HARContentEncoding = typeof BASE64 | undefined;
+
+/**
  * HAR entry with extended timing data
  */
 export interface HarEntry {
@@ -572,7 +583,7 @@ export interface HarEntry {
       size: number;
       mimeType: string;
       text?: string;
-      encoding?: 'base64';
+      encoding: HARContentEncoding;
     };
   };
   time: number;


### PR DESCRIPTION
First slice of the `--baseline` CSS analysis feature. This PR adds extraction of **external stylesheets** from a HAR; inline `<style>` extraction, feature detection (`css-tree`), and Baseline lookup (`web-features`) follow in later PRs.

The extractor is intentionally **not wired into the CLI or `launchTest`** yet — it has no production caller until the detection PR consumes it, so it's exercised entirely by its unit tests. Keeping the slices separate keeps each PR small and isolates new dependencies to the PR that introduces them.

## Changes

### `extractCSSFromHar(harData): CSSSource[]` (`src/baselineCssExtract.ts`)

Collects external CSS a page shipped, from a parsed HAR:

- Selects responses whose `mimeType` starts with `text/css` (case-insensitive, so `Text/CSS; charset=utf-8` matches), using the response body as the CSS source.
- Decodes base64 response bodies to UTF-8 (when HAR `content.encoding === 'base64'`).
- Returns sources in HAR order; entries with no response body are skipped.

Inline `<style>` blocks are out of scope here — they require parsing the HTML document, added in a follow-up PR with a dedicated parser.

### Types (`src/types.ts`)

- Add `CSSSource` (`{ css, file }`).
- Extend `HarEntry.response.content` with optional `text?` and `encoding?` fields (response bodies weren't previously modeled).

## Tests

Adds `packages/telescope/__tests__/baselineCssExtract.test.ts` — 7 pure unit tests (no browser) built from in-memory HAR fixtures:

- External `text/css` extracted with the URL as `file`
- `text/css; charset=utf-8` still matches
- base64-encoded CSS bodies are decoded
- Multiple stylesheets preserve HAR order
- Edge cases: empty HAR, entries with no body, and non-CSS resources (including HTML) ignored