### PR TITLE
Upgrade ffmpeg dependency to node 24

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -71,7 +71,7 @@ jobs:
         run: apt-get update && apt-get install -y xz-utils
 
       - name: Set up FFmpeg
-        uses: FedericoCarboni/setup-ffmpeg@v3
+        uses: FedericoCarboni/setup-ffmpeg@v3.1
 
       - name: Install dependencies
         # don't install the browsers since we're using the pre-built container


### PR DESCRIPTION
Our test CI action is broken when trying to install ffmpeg using `FedericoCarboni/setup-ffmpeg@v3` action that is written for node20, v3.1 is updated to node 24.