### PR TITLE
Harvest inline <style> CSS from the live DOM for Baseline feature detection

### DIFF
--- a/packages/telescope/__tests__/baselineCssExtract.test.ts
+++ b/packages/telescope/__tests__/baselineCssExtract.test.ts
@@ -107,22 +107,24 @@ describe('extractCSSFromHar — ignored and edge cases', () => {
 });
 
 // Inline `<style>` blocks are read from the live DOM rather than the HAR, so
-// these tests drive a real page per rendering engine in the selected matrix
-// (CI runs Firefox only; locally all engines run). setContent leaves the page
-// on `about:blank`, which is what `file` reflects.
-const engines = [
-  ...new Set(
-    BrowserConfig.getBrowsers().map(
-      name => BrowserConfig.browserConfigs[name].engine,
-    ),
-  ),
-];
+// these tests drive a real page in each browser from Telescope's own matrix,
+// launched from that browser's Telescope config (engine + channel + headless)
+// so coverage tracks the browsers Telescope actually runs rather than a
+// separate engine list. setContent leaves the page on `about:blank`, which is
+// what `file` reflects.
+const browsers = BrowserConfig.getBrowsers();
 
-describe.each(engines)('harvestInlineStyles — %s', engine => {
+describe.each(browsers)('harvestInlineStyles — %s', browserName => {
+  const config = BrowserConfig.browserConfigs[browserName];
   let browser: Browser;
 
   beforeAll(async () => {
-    browser = await playwright[engine].launch({ headless: true });
+    browser = await playwright[config.engine].launch({
+      headless: config.headless,
+      ...('channel' in config && config.channel
+        ? { channel: config.channel }
+        : {}),
+    });
   }, 120000);
 
   afterAll(async () => {

--- a/packages/telescope/__tests__/baselineCssExtract.test.ts
+++ b/packages/telescope/__tests__/baselineCssExtract.test.ts
@@ -107,11 +107,8 @@ describe('extractCSSFromHar — ignored and edge cases', () => {
 });
 
 // Inline `<style>` blocks are read from the live DOM rather than the HAR, so
-// these tests drive a real page in each browser from Telescope's own matrix,
-// launched from that browser's Telescope config (engine + channel + headless)
-// so coverage tracks the browsers Telescope actually runs rather than a
-// separate engine list. setContent leaves the page on `about:blank`, which is
-// what `file` reflects.
+// these tests drive a real page in each browser from Telescope's matrix.
+// setContent leaves the page on `about:blank`, which is what `file` reflects.
 const browsers = BrowserConfig.getBrowsers();
 
 describe.each(browsers)('harvestInlineStyles — %s', browserName => {

--- a/packages/telescope/__tests__/baselineCssExtract.test.ts
+++ b/packages/telescope/__tests__/baselineCssExtract.test.ts
@@ -1,6 +1,13 @@
-import { describe, it, expect } from 'vitest';
+import playwright from 'playwright';
+import { afterAll, beforeAll, describe, it, expect } from 'vitest';
 
-import { extractCSSFromHar } from '../src/baselineCssExtract.js';
+import type { Browser, Page } from 'playwright';
+
+import { BrowserConfig } from '../src/browsers.js';
+import {
+  extractCSSFromHar,
+  harvestInlineStyles,
+} from '../src/baselineCssExtract.js';
 import { BASE64 } from '../src/types.js';
 import type { HarData, HarEntry, HARContentEncoding } from '../src/types.js';
 
@@ -96,5 +103,110 @@ describe('extractCSSFromHar — ignored and edge cases', () => {
     ]);
 
     expect(extractCSSFromHar(har)).toEqual([]);
+  });
+});
+
+// Inline `<style>` blocks are read from the live DOM rather than the HAR, so
+// these tests drive a real page per rendering engine in the selected matrix
+// (CI runs Firefox only; locally all engines run). setContent leaves the page
+// on `about:blank`, which is what `file` reflects.
+const engines = [
+  ...new Set(
+    BrowserConfig.getBrowsers().map(
+      name => BrowserConfig.browserConfigs[name].engine,
+    ),
+  ),
+];
+
+describe.each(engines)('harvestInlineStyles — %s', engine => {
+  let browser: Browser;
+
+  beforeAll(async () => {
+    browser = await playwright[engine].launch({ headless: true });
+  }, 120000);
+
+  afterAll(async () => {
+    await browser.close();
+  });
+
+  // Load `html` into a fresh page, run `fn` against it, then discard the page.
+  async function withPage<T>(
+    html: string,
+    fn: (page: Page) => Promise<T>,
+  ): Promise<T> {
+    const page = await browser.newPage();
+    try {
+      await page.setContent(html, { waitUntil: 'load' });
+      return await fn(page);
+    } finally {
+      await page.close();
+    }
+  }
+
+  const harvest = (html: string) =>
+    withPage(html, page => harvestInlineStyles(page));
+
+  it('harvests a single <style> block as one source', async () => {
+    const sources = await harvest('<style>.a { color: red; }</style>');
+
+    expect(sources).toEqual([
+      { css: '.a { color: red; }', file: 'about:blank (inline style #1)' },
+    ]);
+  });
+
+  it('harvests multiple <style> blocks in document order', async () => {
+    const sources = await harvest(
+      '<style>.one {}</style><style>.two {}</style>',
+    );
+
+    expect(sources).toEqual([
+      { css: '.one {}', file: 'about:blank (inline style #1)' },
+      { css: '.two {}', file: 'about:blank (inline style #2)' },
+    ]);
+  });
+
+  // The whole reason for reading the live DOM instead of parsing HTML: styles a
+  // page injects at runtime are present in the rendered document.
+  it('captures <style> blocks injected by JavaScript after load', async () => {
+    const sources = await harvest(
+      `<script>
+        const style = document.createElement('style');
+        style.textContent = '.js { color: green; }';
+        document.head.appendChild(style);
+      </script>`,
+    );
+
+    expect(sources).toEqual([
+      { css: '.js { color: green; }', file: 'about:blank (inline style #1)' },
+    ]);
+  });
+
+  it('returns an empty array when there are no <style> blocks', async () => {
+    expect(await harvest('<p>no styles here</p>')).toEqual([]);
+  });
+
+  it('skips empty and whitespace-only <style> blocks', async () => {
+    const sources = await harvest(
+      '<style></style><style>   </style><style>.a {}</style>',
+    );
+
+    expect(sources).toEqual([
+      { css: '.a {}', file: 'about:blank (inline style #1)' },
+    ]);
+  });
+
+  // Read-only is what lets this run after metrics collection without perturbing
+  // performance measurements; assert it leaves the document untouched.
+  it('does not modify the DOM', async () => {
+    await withPage(
+      '<style>.a { color: red; }</style><main>hi</main>',
+      async page => {
+        const before = await page.content();
+
+        await harvestInlineStyles(page);
+
+        expect(await page.content()).toBe(before);
+      },
+    );
   });
 });

--- a/packages/telescope/__tests__/baselineCssExtract.test.ts
+++ b/packages/telescope/__tests__/baselineCssExtract.test.ts
@@ -195,8 +195,8 @@ describe.each(engines)('harvestInlineStyles — %s', engine => {
     ]);
   });
 
-  // Read-only is what lets this run after metrics collection without perturbing
-  // performance measurements; assert it leaves the document untouched.
+  // Read-only is what lets this run in the shared detection pass without side
+  // effects; assert it leaves the document untouched.
   it('does not modify the DOM', async () => {
     await withPage(
       '<style>.a { color: red; }</style><main>hi</main>',

--- a/packages/telescope/src/baselineCssExtract.ts
+++ b/packages/telescope/src/baselineCssExtract.ts
@@ -1,3 +1,5 @@
+import type { Page } from 'playwright';
+
 import { BASE64 } from './types.js';
 import type { CSSSource, HarData, HARContentEncoding } from './types.js';
 
@@ -5,8 +7,8 @@ import type { CSSSource, HarData, HARContentEncoding } from './types.js';
  * Extract external stylesheets (`text/css` responses) shipped by a page from
  * its HAR.
  *
- * Inline `<style>` blocks in HTML documents are handled separately, in a
- * follow-up change that parses the HTML with a dedicated parser.
+ * Inline `<style>` blocks are handled separately by {@link harvestInlineStyles},
+ * which reads them from the live DOM.
  *
  * @param harData - Parsed HAR file contents.
  * @returns One {@link CSSSource} per stylesheet, in the order they appear in
@@ -25,6 +27,52 @@ export function extractCSSFromHar(harData: HarData): CSSSource[] {
         file: entry.request.url,
       });
     }
+  }
+
+  return sources;
+}
+
+/**
+ * Harvest inline `<style>` blocks from the *live* DOM of a page.
+ *
+ * External stylesheets are recovered from the HAR by {@link extractCSSFromHar};
+ * inline CSS is read here from the rendered document so that `<style>` blocks
+ * injected at runtime (e.g. by JavaScript) are captured — something static HTML
+ * parsing would miss.
+ *
+ * The read is strictly read-only: it neither mutates the DOM nor triggers
+ * layout, so it can run after metrics collection without perturbing
+ * performance measurements.
+ *
+ * Only the text of `<style>` elements in the main document is read. CSS with
+ * no `<style>` text — rules added via `CSSStyleSheet.insertRule()` or
+ * constructable `adoptedStyleSheets` — is not included, nor are `<style>`
+ * elements inside shadow roots (`querySelectorAll` does not pierce shadow DOM)
+ * or `<template>` content.
+ *
+ * @param page - A Playwright page whose document has finished loading.
+ * @returns One {@link CSSSource} per non-empty `<style>` block, in document
+ *   order. `file` identifies the page and the block's position within it.
+ */
+export async function harvestInlineStyles(page: Page): Promise<CSSSource[]> {
+  const blocks = await page.evaluate(() =>
+    // `textContent` on an element is always a string; `?? ''` only satisfies
+    // its `string | null` type (null is unreachable for these nodes).
+    Array.from(
+      document.querySelectorAll('style'),
+      style => style.textContent ?? '',
+    ),
+  );
+
+  const pageUrl = page.url();
+  const sources: CSSSource[] = [];
+  for (const css of blocks) {
+    if (css.trim().length === 0) continue;
+
+    sources.push({
+      css,
+      file: `${pageUrl} (inline style #${sources.length + 1})`,
+    });
   }
 
   return sources;

--- a/packages/telescope/src/baselineCssExtract.ts
+++ b/packages/telescope/src/baselineCssExtract.ts
@@ -65,17 +65,12 @@ export async function harvestInlineStyles(page: Page): Promise<CSSSource[]> {
   );
 
   const pageUrl = page.url();
-  const sources: CSSSource[] = [];
-  for (const css of blocks) {
-    if (css.trim().length === 0) continue;
-
-    sources.push({
+  return blocks
+    .filter(css => css.trim().length > 0)
+    .map((css, index) => ({
       css,
-      file: `${pageUrl} (inline style #${sources.length + 1})`,
-    });
-  }
-
-  return sources;
+      file: `${pageUrl} (inline style #${index + 1})`,
+    }));
 }
 
 /**

--- a/packages/telescope/src/baselineCssExtract.ts
+++ b/packages/telescope/src/baselineCssExtract.ts
@@ -41,8 +41,8 @@ export function extractCSSFromHar(harData: HarData): CSSSource[] {
  * parsing would miss.
  *
  * The read is strictly read-only: it neither mutates the DOM nor triggers
- * layout, so it can run after metrics collection without perturbing
- * performance measurements.
+ * layout, so it can run in the shared Baseline detection pass without
+ * interfering with co-located instrumentation or page state.
  *
  * Only the text of `<style>` elements in the main document is read. CSS with
  * no `<style>` text — rules added via `CSSStyleSheet.insertRule()` or

--- a/packages/telescope/src/types.ts
+++ b/packages/telescope/src/types.ts
@@ -644,10 +644,21 @@ export interface HarData {
 // ============================================================================
 
 /**
- * A block of CSS extracted from a HAR, with its origin location.
+ * A block of CSS to analyse for Baseline feature detection, with its origin.
+ *
+ * Sources come from two places: external stylesheets recovered from the HAR
+ * (see `extractCSSFromHar`) and inline `<style>` blocks read from the live DOM
+ * (see `harvestInlineStyles`).
  */
 export interface CSSSource {
+  /** The CSS text to analyse. This — not {@link file} — is what gets parsed. */
   css: string;
+  /**
+   * Human-readable provenance for reporting where a feature was found. For
+   * external stylesheets this is the request URL; for inline blocks it is a
+   * label derived from the page URL. Treat it as a display string, not a URL to
+   * parse.
+   */
   file: string;
 }
 


### PR DESCRIPTION
Second slice of the `--baseline` CSS analysis feature. This PR adds extraction of **inline `<style>` blocks** by reading them from a page's live DOM; CSS feature detection (`css-tree`) and Baseline lookup (`web-features`) over the collected sources follow in later PRs. (External stylesheets landed in #317.)

Like the external extractor, `harvestInlineStyles` is intentionally **not wired into the CLI or `launchTest`** yet. It is designed to be driven by the **Baseline detection pass** — a live second-pass browser navigation (the same pass that performs JS API detection) — which is productionized in a follow-up PR. Reading inline CSS there keeps all live-DOM detection in one place and one navigation, and runs it once: Baseline analyzes browser-agnostic *source* CSS, so there is no need to repeat it across the browser matrix. Keeping this slice separate keeps each PR small and reviewable.

**Why read the live DOM instead of parsing the HTML?** So that `<style>` blocks a page injects at runtime (e.g. via JavaScript) are captured — static HTML parsing would miss them. The browser is already running in the detection pass, so it is the ground truth for what the page actually applied.

## Changes

### `harvestInlineStyles(page): Promise<CSSSource[]>` (`src/baselineCssExtract.ts`)

Reads inline CSS from a loaded page's live DOM:

- Collects the text of every `<style>` element in document order, returning one `CSSSource` per non-empty block (the same `{ css, file }` shape as `extractCSSFromHar`).
- Skips empty / whitespace-only blocks.
- The read is strictly **read-only** — a single `page.evaluate` that reads `<style>` text with no DOM mutation and no layout-triggering reads — so it can run inside the shared detection pass without interfering with co-located instrumentation or page state.

**Out of scope** (documented in the JSDoc; may be revisited later): only `<style>` element text is read, so CSS with no `<style>` text — rules added via `CSSStyleSheet.insertRule()` or constructable `adoptedStyleSheets` — is not captured, nor are `<style>` elements inside shadow roots (`querySelectorAll` does not pierce shadow DOM) or `<template>` content.

### Types (`src/types.ts`)

- Document `CSSSource`: `css` is the field that gets parsed; `file` is a provenance label for reporting — a URL for external stylesheets, a page-derived label (e.g. `https://example.com/ (inline style #1)`) for inline blocks. It is a display string, not a URL to parse.

## Tests

Extends `packages/telescope/__tests__/baselineCssExtract.test.ts` with 6 tests parameterized per rendering engine (chromium/firefox/webkit; Firefox-only in CI), driving a real page via `setContent`:

- Single `<style>` block extracted as one source
- Multiple blocks preserved in document order
- **`<style>` injected by JavaScript after load is captured** (the case static parsing misses)
- No `<style>` blocks → empty array
- Empty / whitespace-only blocks skipped
- **Read-only guarantee**: harvesting leaves the document markup unchanged
