### PR TITLE
Add Baseline CLI pipeline skeleton

### DIFF
--- a/packages/telescope/__tests__/baseline.test.ts
+++ b/packages/telescope/__tests__/baseline.test.ts
@@ -1,0 +1,116 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import type { Server } from 'node:http';
+
+import { afterAll, beforeAll, describe, expect, test } from 'vitest';
+
+import { runBaselinePipeline, writeBaselineArtifact } from '../src/baseline.js';
+import { BrowserConfig } from '../src/browsers.js';
+import { launchTest } from '../src/index.js';
+import type { BrowserName } from '../src/types.js';
+import { cleanupTestDirectory } from './helpers.js';
+import {
+  createStaticServer,
+  fixturesDir,
+  listenServer,
+  shutdownServer,
+} from './testServer.js';
+
+const browsers: BrowserName[] = BrowserConfig.getBrowsers();
+const packageVersion = (
+  JSON.parse(fs.readFileSync(path.resolve('package.json'), 'utf8')) as {
+    version: string;
+  }
+).version;
+let baseUrl: string;
+let server: Server;
+
+beforeAll(async () => {
+  server = createStaticServer({ fixturesDirPath: fixturesDir('delay') });
+  baseUrl = await listenServer(server);
+});
+
+afterAll(async () => {
+  await shutdownServer(server);
+});
+
+describe.each(browsers)('Baseline pipeline artifacts (%s)', browser => {
+  test.each([
+    ['enabled', true, true],
+    ['disabled', false, false],
+    ['omitted', undefined, false],
+  ])(
+    'writes artifacts when baseline is %s',
+    async (_case, baseline, enabled) => {
+      const result = await launchTest({
+        baseline,
+        browser,
+        url: `${baseUrl}/index.html`,
+      });
+      if (!result.success) throw new Error(result.error);
+      try {
+        const baselinePath = path.join(result.resultsPath, 'baseline');
+        expect(fs.existsSync(baselinePath)).toBe(enabled);
+        if (enabled) {
+          expect(fs.existsSync(path.join(baselinePath, 'meta.json'))).toBe(
+            true,
+          );
+        }
+      } finally {
+        cleanupTestDirectory(result.testId);
+      }
+    },
+    60000,
+  );
+});
+
+test('the pipeline isolates performance artifacts and writes stable JSON', async () => {
+  fs.mkdirSync(path.resolve('results'), { recursive: true });
+  const resultsPath = fs.mkdtempSync(
+    path.join(process.cwd(), 'results', 'baseline-isolation-'),
+  );
+  const harPath = path.join(resultsPath, 'pageload.har');
+  const metricsPath = path.join(resultsPath, 'metrics.json');
+  const har = '{"log":{"entries":[]}}';
+  const metrics = '{"firstContentfulPaint":123}';
+  fs.writeFileSync(harPath, har);
+  fs.writeFileSync(metricsPath, metrics);
+
+  try {
+    await runBaselinePipeline({
+      resultsPath,
+      url: 'https://example.com',
+    });
+
+    const meta = JSON.parse(
+      fs.readFileSync(path.join(resultsPath, 'baseline', 'meta.json'), 'utf8'),
+    ) as Record<string, unknown>;
+    expect(meta).toEqual({
+      schemaVersion: 1,
+      telescopeVersion: packageVersion,
+      timestamp: expect.any(String),
+      url: 'https://example.com',
+    });
+    expect(new Date(meta.timestamp as string).toISOString()).toBe(
+      meta.timestamp,
+    );
+    expect(fs.readFileSync(harPath, 'utf8')).toBe(har);
+    expect(fs.readFileSync(metricsPath, 'utf8')).toBe(metrics);
+    writeBaselineArtifact(resultsPath, 'detection/example.json', {
+      z: [{ b: 2, a: 1 }],
+      a: { d: 4, c: 3 },
+    });
+
+    expect(
+      fs.readFileSync(
+        path.join(resultsPath, 'baseline', 'detection', 'example.json'),
+        'utf8',
+      ),
+    ).toBe('{"a":{"c":3,"d":4},"z":[{"a":1,"b":2}]}');
+    expect(() =>
+      writeBaselineArtifact(resultsPath, '../outside.json', {}),
+    ).toThrow('Invalid baseline artifact path');
+  } finally {
+    fs.rmSync(resultsPath, { recursive: true, force: true });
+  }
+});

--- a/packages/telescope/__tests__/baseline.test.ts
+++ b/packages/telescope/__tests__/baseline.test.ts
@@ -4,7 +4,11 @@ import type { Server } from 'node:http';
 
 import { afterAll, beforeAll, describe, expect, test } from 'vitest';
 
-import { runBaselinePipeline, writeBaselineArtifact } from '../src/baseline.js';
+import {
+  BASELINE_SCHEMA_VERSION,
+  runBaselinePipeline,
+  writeBaselineArtifact,
+} from '../src/baseline.js';
 import { BrowserConfig } from '../src/browsers.js';
 import { launchTest } from '../src/index.js';
 import type { BrowserName } from '../src/types.js';
@@ -64,7 +68,7 @@ describe.each(browsers)('Baseline pipeline artifacts (%s)', browser => {
   );
 });
 
-test('the pipeline isolates performance artifacts and writes stable JSON', async () => {
+test('the pipeline writes a run manifest and isolates performance artifacts', async () => {
   fs.mkdirSync(path.resolve('results'), { recursive: true });
   const resultsPath = fs.mkdtempSync(
     path.join(process.cwd(), 'results', 'baseline-isolation-'),
@@ -86,7 +90,7 @@ test('the pipeline isolates performance artifacts and writes stable JSON', async
       fs.readFileSync(path.join(resultsPath, 'baseline', 'meta.json'), 'utf8'),
     ) as Record<string, unknown>;
     expect(meta).toEqual({
-      schemaVersion: 1,
+      schemaVersion: BASELINE_SCHEMA_VERSION,
       telescopeVersion: packageVersion,
       timestamp: expect.any(String),
       url: 'https://example.com',
@@ -96,17 +100,29 @@ test('the pipeline isolates performance artifacts and writes stable JSON', async
     );
     expect(fs.readFileSync(harPath, 'utf8')).toBe(har);
     expect(fs.readFileSync(metricsPath, 'utf8')).toBe(metrics);
-    writeBaselineArtifact(resultsPath, 'detection/example.json', {
-      z: [{ b: 2, a: 1 }],
-      a: { d: 4, c: 3 },
-    });
+  } finally {
+    fs.rmSync(resultsPath, { recursive: true, force: true });
+  }
+});
 
-    expect(
+test('writeBaselineArtifact round-trips content and blocks path escapes', () => {
+  fs.mkdirSync(path.resolve('results'), { recursive: true });
+  const resultsPath = fs.mkdtempSync(
+    path.join(process.cwd(), 'results', 'baseline-artifact-'),
+  );
+
+  try {
+    const artifact = { detected: ['grid', 'flexbox'] };
+    writeBaselineArtifact(resultsPath, 'detection/example.json', artifact);
+
+    const written = JSON.parse(
       fs.readFileSync(
         path.join(resultsPath, 'baseline', 'detection', 'example.json'),
         'utf8',
       ),
-    ).toBe('{"a":{"c":3,"d":4},"z":[{"a":1,"b":2}]}');
+    ) as unknown;
+    expect(written).toEqual(artifact);
+
     expect(() =>
       writeBaselineArtifact(resultsPath, '../outside.json', {}),
     ).toThrow('Invalid baseline artifact path');

--- a/packages/telescope/__tests__/baselineError.test.ts
+++ b/packages/telescope/__tests__/baselineError.test.ts
@@ -1,0 +1,47 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+import { expect, test, vi } from 'vitest';
+
+const { runBaselinePipelineMock } = vi.hoisted(() => ({
+  runBaselinePipelineMock: vi.fn(),
+}));
+
+vi.mock('../src/baseline.js', () => ({
+  runBaselinePipeline: runBaselinePipelineMock,
+}));
+
+import { BrowserConfig } from '../src/browsers.js';
+import { launchTest } from '../src/index.js';
+import { cleanupTestDirectory } from './helpers.js';
+
+test('a baseline pipeline error is logged without failing the performance test', async () => {
+  const error = new Error('artifact write failed');
+  const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+  runBaselinePipelineMock.mockImplementationOnce(
+    ({ resultsPath }: { resultsPath: string }) => {
+      expect(fs.existsSync(path.join(resultsPath, 'pageload.har'))).toBe(true);
+      expect(fs.existsSync(path.join(resultsPath, 'metrics.json'))).toBe(true);
+      return Promise.reject(error);
+    },
+  );
+  let testId: string | undefined;
+
+  try {
+    const result = await launchTest({
+      baseline: true,
+      browser: BrowserConfig.getBrowsers()[0],
+      url: 'https://example.com',
+    });
+
+    expect(result.success).toBe(true);
+    if (!result.success) {
+      throw new Error(result.error);
+    }
+    testId = result.testId;
+    expect(errorSpy).toHaveBeenCalledWith('Baseline pipeline error: ' + error);
+  } finally {
+    errorSpy.mockRestore();
+    cleanupTestDirectory(testId);
+  }
+}, 60000);

--- a/packages/telescope/__tests__/cliArgs.test.ts
+++ b/packages/telescope/__tests__/cliArgs.test.ts
@@ -29,8 +29,38 @@ describe('CLI: no arguments shows help', () => {
     expect(stdout).toContain('--url');
   });
 
+  it('lists the --baseline option in help', () => {
+    expect(stdout).toContain('--baseline');
+  });
+
   it('does not write anything to stderr', () => {
     expect(stderr).toBe('');
+  });
+});
+
+function readBaselineFromDryRun(baselineArgs: string[]): boolean | undefined {
+  let testId: string | undefined;
+  try {
+    const output = spawnSync('node', [
+      'dist/src/cli.js',
+      '--dry',
+      ...baselineArgs,
+      'https://www.example.com',
+    ]);
+    const match = output.stdout.toString().match(/Test ID:(.*)/);
+    if (match && match.length > 1) {
+      testId = match[1].trim();
+      return retrieveConfig(testId)?.options.baseline;
+    }
+  } finally {
+    cleanupTestDirectory(testId);
+  }
+}
+
+describe('CLI: baseline option', () => {
+  it('stores true when present and defaults to false when absent', () => {
+    expect(readBaselineFromDryRun(['--baseline'])).toBe(true);
+    expect(readBaselineFromDryRun([])).toBe(false);
   });
 });
 

--- a/packages/telescope/src/baseline.ts
+++ b/packages/telescope/src/baseline.ts
@@ -1,0 +1,67 @@
+import { mkdirSync, writeFileSync } from 'node:fs';
+import path from 'node:path';
+
+import { getPackageVersion } from './packageVersion.js';
+import type { BaselinePipelineOptions, JsonValue } from './types.js';
+
+const BASELINE_SCHEMA_VERSION = 1;
+
+function sortJson(value: JsonValue): JsonValue {
+  if (Array.isArray(value)) {
+    return value.map(sortJson);
+  }
+  if (value !== null && typeof value === 'object') {
+    return Object.fromEntries(
+      Object.entries(value)
+        .sort(([left], [right]) => (left < right ? -1 : left > right ? 1 : 0))
+        .map(([key, child]) => [key, sortJson(child)]),
+    );
+  }
+  return value;
+}
+
+/**
+ * Writes a deterministic JSON artifact beneath the results baseline directory.
+ * @param resultsPath - Directory containing the performance test results.
+ * @param artifactPath - Path relative to the baseline directory.
+ * @param artifact - JSON-compatible artifact content.
+ * @throws If the artifact path escapes the baseline directory or writing fails.
+ */
+export function writeBaselineArtifact(
+  resultsPath: string,
+  artifactPath: string,
+  artifact: JsonValue,
+): void {
+  const baselinePath = path.resolve(resultsPath, 'baseline');
+  const outputPath = path.resolve(baselinePath, artifactPath);
+  if (
+    outputPath !== baselinePath &&
+    !outputPath.startsWith(baselinePath + path.sep)
+  ) {
+    throw new Error(`Invalid baseline artifact path: ${artifactPath}`);
+  }
+
+  mkdirSync(path.dirname(outputPath), { recursive: true });
+  writeFileSync(outputPath, JSON.stringify(sortJson(artifact)), 'utf8');
+}
+
+/**
+ * Runs the post-performance Baseline analysis pipeline.
+ *
+ * Detection and analysis stages will be added incrementally. The initial
+ * pipeline writes only a run manifest to establish the artifact contract.
+ *
+ * @param options - Completed test URL and results location.
+ */
+export async function runBaselinePipeline(
+  options: BaselinePipelineOptions,
+): Promise<void> {
+  const meta = {
+    schemaVersion: BASELINE_SCHEMA_VERSION,
+    telescopeVersion: getPackageVersion(),
+    timestamp: new Date().toISOString(),
+    url: options.url,
+  };
+
+  writeBaselineArtifact(options.resultsPath, 'meta.json', meta);
+}

--- a/packages/telescope/src/baseline.ts
+++ b/packages/telescope/src/baseline.ts
@@ -2,26 +2,12 @@ import { mkdirSync, writeFileSync } from 'node:fs';
 import path from 'node:path';
 
 import { getPackageVersion } from './packageVersion.js';
-import type { BaselinePipelineOptions, JsonValue } from './types.js';
+import type { BaselinePipelineOptions, JSONValue } from './types.js';
 
-const BASELINE_SCHEMA_VERSION = 1;
-
-function sortJson(value: JsonValue): JsonValue {
-  if (Array.isArray(value)) {
-    return value.map(sortJson);
-  }
-  if (value !== null && typeof value === 'object') {
-    return Object.fromEntries(
-      Object.entries(value)
-        .sort(([left], [right]) => (left < right ? -1 : left > right ? 1 : 0))
-        .map(([key, child]) => [key, sortJson(child)]),
-    );
-  }
-  return value;
-}
+export const BASELINE_SCHEMA_VERSION = 1;
 
 /**
- * Writes a deterministic JSON artifact beneath the results baseline directory.
+ * Writes a JSON artifact beneath the results baseline directory.
  * @param resultsPath - Directory containing the performance test results.
  * @param artifactPath - Path relative to the baseline directory.
  * @param artifact - JSON-compatible artifact content.
@@ -30,7 +16,7 @@ function sortJson(value: JsonValue): JsonValue {
 export function writeBaselineArtifact(
   resultsPath: string,
   artifactPath: string,
-  artifact: JsonValue,
+  artifact: JSONValue,
 ): void {
   const baselinePath = path.resolve(resultsPath, 'baseline');
   const outputPath = path.resolve(baselinePath, artifactPath);
@@ -42,7 +28,7 @@ export function writeBaselineArtifact(
   }
 
   mkdirSync(path.dirname(outputPath), { recursive: true });
-  writeFileSync(outputPath, JSON.stringify(sortJson(artifact)), 'utf8');
+  writeFileSync(outputPath, JSON.stringify(artifact), 'utf8');
 }
 
 /**

--- a/packages/telescope/src/chromeRunner.ts
+++ b/packages/telescope/src/chromeRunner.ts
@@ -1,16 +1,11 @@
 import { TestRunner } from './testRunner.js';
 import { log } from './helpers.js';
-import type { BrowserConfigOptions, LaunchOptions, PriorityInfo } from './types.js';
+import type { PriorityInfo } from './types.js';
 import type { BrowserContext, Page, CDPSession } from 'playwright';
 
 const TELESCOPE_ID_HEADER = 'x-telescope-id';
 
 class ChromeRunner extends TestRunner {
-  constructor(options: LaunchOptions, browserConfig: BrowserConfigOptions) {
-    //call parent
-    super(options, browserConfig);
-  }
-
   /**
    * Given a browser instance, grab the page and then kick off anything that
    * needs to be attached at the page level

--- a/packages/telescope/src/config.ts
+++ b/packages/telescope/src/config.ts
@@ -45,6 +45,7 @@ export function normalizeCLIConfig(options: CLIOptions): LaunchOptions {
   }
   const config: LaunchOptions = {
     url: options.url,
+    baseline: options.baseline || DEFAULT_OPTIONS.baseline,
     browser: options.browser as BrowserName | undefined,
     width: options.width,
     height: options.height,

--- a/packages/telescope/src/config.ts
+++ b/packages/telescope/src/config.ts
@@ -45,7 +45,7 @@ export function normalizeCLIConfig(options: CLIOptions): LaunchOptions {
   }
   const config: LaunchOptions = {
     url: options.url,
-    baseline: options.baseline || DEFAULT_OPTIONS.baseline,
+    baseline: options.baseline ?? DEFAULT_OPTIONS.baseline,
     browser: options.browser as BrowserName | undefined,
     width: options.width,
     height: options.height,

--- a/packages/telescope/src/defaultOptions.ts
+++ b/packages/telescope/src/defaultOptions.ts
@@ -6,6 +6,8 @@ import type { DefaultOptions } from './types.js';
  * Single source of truth prevents defaults from drifting between interfaces.
  */
 export const DEFAULT_OPTIONS: DefaultOptions = {
+  // Run Baseline compatibility analysis
+  baseline: false,
   // Browser engine to use for testing
   browser: 'chrome',
   // Filmstrip capture rate (frames per second)

--- a/packages/telescope/src/index.ts
+++ b/packages/telescope/src/index.ts
@@ -120,7 +120,7 @@ async function executeTest(
   const config: TestConfig = {
     ...DEFAULT_OPTIONS,
     ...options,
-    baseline: options.baseline || DEFAULT_OPTIONS.baseline,
+    baseline: options.baseline ?? DEFAULT_OPTIONS.baseline,
   };
   const browserConfig = new BrowserConfig().getBrowserConfig(
     config.browser || 'chrome',

--- a/packages/telescope/src/index.ts
+++ b/packages/telescope/src/index.ts
@@ -1,7 +1,3 @@
-import { readFileSync } from 'fs';
-import path from 'path';
-import url from 'url';
-
 import { Command, Option, InvalidArgumentError } from 'commander';
 const program = new Command();
 import { BrowserConfig } from './browsers.js';
@@ -21,6 +17,7 @@ import {
   DelaySchema,
 } from './schemas.js';
 import { parseWithSchema, parseCLIOption } from './validation.js';
+import { getPackageVersion } from './packageVersion.js';
 import type { ZodSchema } from 'zod';
 
 function parseNumeric<T>(schema: ZodSchema<T>, value: string, flag: string): T {
@@ -39,47 +36,10 @@ function parseJSON<T>(flag: string, value: string, schema: ZodSchema<T>): T {
   }
 }
 
-/**
- * Read the package version from package.json at runtime.
- *
- * Walks up the directory tree from this module's location looking for the
- * first `package.json` whose `name` matches `@cloudflare/telescope`. This
- * works regardless of whether the code runs from source (`src/index.ts`) or
- * compiled output (`dist/src/index.js`), and is cross-platform (no reliance
- * on POSIX-only path separators).
- */
-function getPackageVersion(): string {
-  const startDir = path.dirname(url.fileURLToPath(import.meta.url));
-  let dir = startDir;
-
-  // Walk up until we either find our package.json or hit the filesystem root.
-  while (true) {
-    const candidate = path.join(dir, 'package.json');
-    try {
-      const pkg = JSON.parse(readFileSync(candidate, 'utf8')) as {
-        name?: string;
-        version?: string;
-      };
-      if (pkg.name === '@cloudflare/telescope' && pkg.version) {
-        return pkg.version;
-      }
-    } catch {
-      // No package.json at this level (or unreadable); keep walking.
-    }
-    const parent = path.dirname(dir);
-    if (parent === dir) {
-      // Reached the filesystem root without finding our package.json.
-      throw new Error(
-        'Unable to locate @cloudflare/telescope package.json to read version',
-      );
-    }
-    dir = parent;
-  }
-}
-
 import type {
   LaunchOptions,
   BrowserConfigOptions,
+  TestConfig,
   SuccessfulTestResult,
   FailedTestResult,
   TestResult,
@@ -124,7 +84,7 @@ export class Telescope {
  * Get the appropriate runner based on the browser engine
  */
 function getRunner(
-  options: LaunchOptions,
+  options: TestConfig,
   browserConfig: BrowserConfigOptions,
 ): TestRunner {
   if (browserConfig.engine === 'chromium') {
@@ -157,9 +117,10 @@ async function executeTest(
       `Only http:// and https:// URLs are supported (got "${options.url}")`,
     );
   }
-  const config: LaunchOptions = {
+  const config: TestConfig = {
     ...DEFAULT_OPTIONS,
     ...options,
+    baseline: options.baseline || DEFAULT_OPTIONS.baseline,
   };
   const browserConfig = new BrowserConfig().getBrowserConfig(
     config.browser || 'chrome',
@@ -358,6 +319,12 @@ export default function browserAgent(): void {
       )
         .default(DEFAULT_OPTIONS.frameRate)
         .argParser(v => parseNumeric(PositiveIntSchema, v, '--frameRate')),
+    )
+    .addOption(
+      new Option(
+        '--baseline',
+        'Run Baseline web platform compatibility analysis',
+      ).default(DEFAULT_OPTIONS.baseline),
     )
     .addOption(
       new Option('--disableJS', 'Disable JavaScript').default(

--- a/packages/telescope/src/index.ts
+++ b/packages/telescope/src/index.ts
@@ -39,7 +39,6 @@ function parseJSON<T>(flag: string, value: string, schema: ZodSchema<T>): T {
 import type {
   LaunchOptions,
   BrowserConfigOptions,
-  TestConfig,
   SuccessfulTestResult,
   FailedTestResult,
   TestResult,
@@ -84,7 +83,7 @@ export class Telescope {
  * Get the appropriate runner based on the browser engine
  */
 function getRunner(
-  options: TestConfig,
+  options: LaunchOptions,
   browserConfig: BrowserConfigOptions,
 ): TestRunner {
   if (browserConfig.engine === 'chromium') {
@@ -117,7 +116,7 @@ async function executeTest(
       `Only http:// and https:// URLs are supported (got "${options.url}")`,
     );
   }
-  const config: TestConfig = {
+  const config: LaunchOptions = {
     ...DEFAULT_OPTIONS,
     ...options,
     baseline: options.baseline ?? DEFAULT_OPTIONS.baseline,

--- a/packages/telescope/src/packageVersion.ts
+++ b/packages/telescope/src/packageVersion.ts
@@ -1,0 +1,35 @@
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import url from 'node:url';
+
+/**
+ * Reads Telescope's version from its nearest package manifest.
+ * @returns The package version.
+ * @throws If the Telescope package manifest cannot be found.
+ */
+export function getPackageVersion(): string {
+  let directory = path.dirname(url.fileURLToPath(import.meta.url));
+
+  while (true) {
+    const candidate = path.join(directory, 'package.json');
+    try {
+      const packageJson = JSON.parse(readFileSync(candidate, 'utf8')) as {
+        name?: string;
+        version?: string;
+      };
+      if (packageJson.name === '@cloudflare/telescope' && packageJson.version) {
+        return packageJson.version;
+      }
+    } catch {
+      // The package manifest may be higher in the directory tree.
+    }
+
+    const parent = path.dirname(directory);
+    if (parent === directory) {
+      throw new Error(
+        'Unable to locate @cloudflare/telescope package.json to read version',
+      );
+    }
+    directory = parent;
+  }
+}

--- a/packages/telescope/src/testRunner.ts
+++ b/packages/telescope/src/testRunner.ts
@@ -38,7 +38,7 @@ import crypto from 'crypto';
 import type {
   BrowserConfigOptions,
   SimplifiedBrowserConfigOptions,
-  TestConfig,
+  LaunchOptions,
   TestPaths,
   ResultAssets,
   Metrics,
@@ -76,7 +76,7 @@ class TestRunner {
     filmstripFiles: [],
     videoFile: null,
   };
-  options: TestConfig;
+  options: LaunchOptions;
   testURL: string;
   selectedBrowser: BrowserConfigOptions;
   TESTID: string;
@@ -84,7 +84,7 @@ class TestRunner {
   browserInstance: BrowserContext | null = null;
   page: Page | null = null;
 
-  constructor(options: TestConfig, browserConfig: BrowserConfigOptions) {
+  constructor(options: LaunchOptions, browserConfig: BrowserConfigOptions) {
     this.options = options;
     this.testURL = options.url;
     this.selectedBrowser = browserConfig;

--- a/packages/telescope/src/testRunner.ts
+++ b/packages/telescope/src/testRunner.ts
@@ -38,7 +38,7 @@ import crypto from 'crypto';
 import type {
   BrowserConfigOptions,
   SimplifiedBrowserConfigOptions,
-  LaunchOptions,
+  TestConfig,
   TestPaths,
   ResultAssets,
   Metrics,
@@ -57,6 +57,7 @@ import type {
 } from './types.js';
 import type { BrowserContext, Page, Route, Request } from 'playwright';
 import { delayUsingFulfill, delayUsingContinue } from './delay.js';
+import { runBaselinePipeline } from './baseline.js';
 
 const TELESCOPE_ID_HEADER = 'x-telescope-id';
 
@@ -75,7 +76,7 @@ class TestRunner {
     filmstripFiles: [],
     videoFile: null,
   };
-  options: LaunchOptions;
+  options: TestConfig;
   testURL: string;
   selectedBrowser: BrowserConfigOptions;
   TESTID: string;
@@ -83,7 +84,7 @@ class TestRunner {
   browserInstance: BrowserContext | null = null;
   page: Page | null = null;
 
-  constructor(options: LaunchOptions, browserConfig: BrowserConfigOptions) {
+  constructor(options: TestConfig, browserConfig: BrowserConfigOptions) {
     this.options = options;
     this.testURL = options.url;
     this.selectedBrowser = browserConfig;
@@ -763,6 +764,17 @@ class TestRunner {
       );
     } catch (err) {
       console.error('Error writing resources file ' + err);
+    }
+
+    if (this.options.baseline) {
+      try {
+        await runBaselinePipeline({
+          resultsPath: this.paths['results'],
+          url: this.testURL,
+        });
+      } catch (err) {
+        console.error('Baseline pipeline error: ' + err);
+      }
     }
 
     //create our filmstrip

--- a/packages/telescope/src/types.ts
+++ b/packages/telescope/src/types.ts
@@ -231,13 +231,6 @@ export interface DefaultOptions {
   device?: CustomDeviceDescriptor;
 }
 
-/**
- * Options used internally after the Baseline default has been applied.
- */
-export interface TestConfig extends LaunchOptions {
-  baseline: boolean;
-}
-
 // ============================================================================
 // Test Results
 // ============================================================================
@@ -652,11 +645,11 @@ export interface HarData {
 // Baseline Types
 // ============================================================================
 
-export type JsonPrimitive = boolean | number | string | null;
-export type JsonValue =
-  | JsonPrimitive
-  | JsonValue[]
-  | { [key: string]: JsonValue };
+export type JSONPrimitive = boolean | number | string | null;
+export type JSONValue =
+  | JSONPrimitive
+  | JSONValue[]
+  | { [key: string]: JSONValue };
 
 /**
  * Inputs available to the post-performance Baseline pipeline.

--- a/packages/telescope/src/types.ts
+++ b/packages/telescope/src/types.ts
@@ -171,6 +171,7 @@ export type SimplifiedBrowserConfigOptions = Omit<
  */
 export interface LaunchOptions {
   url: string;
+  baseline?: boolean;
   browser?: BrowserName;
   headers?: Record<string, string>;
   cookies?: Cookie | Cookie[];
@@ -206,6 +207,7 @@ export interface LaunchOptions {
  * Default options type (subset of LaunchOptions that have defaults)
  */
 export interface DefaultOptions {
+  baseline: boolean;
   browser: BrowserName;
   width?: number;
   height?: number;
@@ -227,6 +229,13 @@ export interface DefaultOptions {
   delay: Record<string, number>;
   delayUsing: DelayMethod;
   device?: CustomDeviceDescriptor;
+}
+
+/**
+ * Options used internally after the Baseline default has been applied.
+ */
+export interface TestConfig extends LaunchOptions {
+  baseline: boolean;
 }
 
 // ============================================================================
@@ -643,6 +652,20 @@ export interface HarData {
 // Baseline Types
 // ============================================================================
 
+export type JsonPrimitive = boolean | number | string | null;
+export type JsonValue =
+  | JsonPrimitive
+  | JsonValue[]
+  | { [key: string]: JsonValue };
+
+/**
+ * Inputs available to the post-performance Baseline pipeline.
+ */
+export interface BaselinePipelineOptions {
+  resultsPath: string;
+  url: string;
+}
+
 /**
  * A block of CSS extracted from a HAR, with its origin location.
  */
@@ -681,6 +704,7 @@ declare global {
  */
 export interface CLIOptions {
   url?: string;
+  baseline?: boolean;
   browser?: string;
   headers?: Record<string, string>;
   cookies?: Cookie | Cookie[];


### PR DESCRIPTION
Introduces the `--baseline` entry point and the initial Baseline pipeline infrastructure. When enabled, the pipeline runs after the performance navigation has completed, the browser has closed, and the HAR and metrics artifacts have been finalized.

The pipeline is intentionally minimal in this PR: it establishes option plumbing, execution ordering, error isolation, and the artifact-writing convention by producing `baseline/meta.json`. Feature detection, the separate detection navigation, Baseline status lookup, and final status-split reports follow in later PRs.

## Changes

### `--baseline` option

- Adds a boolean `--baseline` CLI option, defaulting to `false`.
- Threads the option through CLI normalization and the programmatic `launchTest` API.
- Adds the option to `LaunchOptions`, `DefaultOptions`, `CLIOptions`, and the normalized internal `TestConfig`.
- Preserves the normalized `baseline: boolean` guarantee through the browser runners.

### Baseline pipeline (`src/baseline.ts`)

Adds `runBaselinePipeline`, invoked during post-processing after the HAR and metrics have been written.

For this initial slice, it writes:

```text
baseline/meta.json
```
The manifest contains:

- Tested URL
- ISO timestamp
- Telescope package version
- Artifact schema version

The existing performance browser is not reused, and no separate detection browser is launched yet.

### Artifact writer

Adds a reusable `writeBaselineArtifact` function that:

- Namespaces all output beneath `baseline/`.
- Supports nested intermediary paths such as `baseline/detection/`.
- Produces deterministic JSON by sorting object keys.
- Rejects paths that would escape the Baseline directory.
- Accepts only JSON-compatible values through the shared `JsonValue` type.

Later slices can use the same writer for intermediary detection artifacts and the final reports split by Baseline status.

### Error isolation

Baseline pipeline errors are logged without failing the performance test. Existing HAR, metrics, and other performance results remain available if Baseline processing fails.

### Package version helper

Moves the existing package-version lookup from `index.ts` into a focused shared module so both the CLI version flag and Baseline metadata use the same implementation.

## Tests

Adds coverage for:

- `--baseline` appearing in CLI help.
- CLI parsing with the flag enabled and omitted.
- `baseline: true`, `false`, and omitted across the browser matrix using the local delay fixture.
- Creation and contents of `baseline/meta.json`.
- No Baseline directory when the option is disabled or omitted.
- Byte-for-byte isolation of existing HAR and metrics artifacts.
- Deterministic nested artifact output.
- Rejection of paths outside the Baseline directory.
- Pipeline execution after HAR and metrics creation.
- Baseline errors being logged and swallowed without changing the successful performance result.