### PR TITLE
Detect CSS declaration features for Baseline

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3728,6 +3728,13 @@
                 "assertion-error": "^2.0.1"
             }
         },
+        "node_modules/@types/css-tree": {
+            "version": "2.3.11",
+            "resolved": "https://registry.npmjs.org/@types/css-tree/-/css-tree-2.3.11.tgz",
+            "integrity": "sha512-aEokibJOI77uIlqoBOkVbaQGC9zII0A+JH1kcTNKW2CwyYWD8KM6qdo+4c77wD3wZOQfJuNWAr9M4hdk+YhDIg==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/@types/d3-array": {
             "version": "3.0.3",
             "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.0.3.tgz",
@@ -10941,6 +10948,7 @@
                 "@sitespeed.io/throttle": "^5.0.0",
                 "adm-zip": "^0.6.0",
                 "commander": "^10.0.0",
+                "css-tree": "^3.2.1",
                 "ejs": "^6.0.1",
                 "ffmpeg": "^0.0.4",
                 "playwright": "^1.61.1",
@@ -10953,6 +10961,7 @@
             "devDependencies": {
                 "@eslint/js": "^10.0.1",
                 "@playwright/test": "^1.61.1",
+                "@types/css-tree": "^2.3.11",
                 "@types/ejs": "^3.1.5",
                 "@types/node": "^25.2.1",
                 "@typescript-eslint/eslint-plugin": "^8.65.0",

--- a/packages/telescope/__tests__/baselineCssDetect.test.ts
+++ b/packages/telescope/__tests__/baselineCssDetect.test.ts
@@ -1,0 +1,209 @@
+import { describe, expect, it } from 'vitest';
+
+import { detectCSSFeatures } from '../src/baselineCssDetect.js';
+
+const TEST_FILE = 'test.css';
+
+function detectKeys(css: string): string[] {
+  return detectCSSFeatures([{ css, file: TEST_FILE }]).map(
+    detection => detection.bcdKey,
+  );
+}
+
+describe('detectCSSFeatures', () => {
+  it('detects properties and single-keyword values with their source lines', () => {
+    const detections = detectCSSFeatures([
+      {
+        css: '.card {\n  display: grid;\n  color: var(--brand);\n}',
+        file: 'https://example.com/styles.css',
+      },
+    ]);
+
+    expect(detections).toEqual([
+      {
+        type: 'property',
+        bcdKey: 'css.properties.display',
+        property: 'display',
+        source: { file: 'https://example.com/styles.css', line: 2 },
+      },
+      {
+        type: 'property-value',
+        bcdKey: 'css.properties.display.grid',
+        property: 'display',
+        value: 'grid',
+        source: { file: 'https://example.com/styles.css', line: 2 },
+      },
+      {
+        type: 'property',
+        bcdKey: 'css.properties.color',
+        property: 'color',
+        source: { file: 'https://example.com/styles.css', line: 3 },
+      },
+    ]);
+  });
+
+  it('normalizes case for case-insensitive CSS names and values', () => {
+    expect(detectKeys('a { DISPLAY: GRID; }')).toEqual([
+      'css.properties.display',
+      'css.properties.display.grid',
+    ]);
+  });
+
+  it.each([
+    ['color', 'CURRENTCOLOR', 'currentColor'],
+    ['text-rendering', 'GEOMETRICPRECISION', 'geometricPrecision'],
+    ['color-interpolation', 'LINEARRGB', 'linearRGB'],
+    ['color-interpolation', 'SRGB', 'sRGB'],
+  ])('preserves canonical BCD casing for %s: %s', (property, value, key) => {
+    expect(detectKeys(`a { ${property}: ${value}; }`)).toEqual([
+      `css.properties.${property}`,
+      `css.properties.${property}.${key}`,
+    ]);
+  });
+
+  it('does not rewrite values that only resemble canonical BCD segments', () => {
+    expect(detectKeys('a { color-interpolation: lineargradient; }')).toEqual([
+      'css.properties.color-interpolation',
+      'css.properties.color-interpolation.lineargradient',
+    ]);
+  });
+
+  it('maps CSS-wide keywords through their shared BCD namespace', () => {
+    expect(detectKeys('a { color: REVERT-LAYER; }')).toEqual([
+      'css.properties.color',
+      'css.types.global_keywords.revert-layer',
+    ]);
+  });
+
+  it('does not treat conditional-query operands as applied declarations', () => {
+    expect(detectKeys('@supports (display: grid) {}')).toEqual([]);
+    expect(
+      detectKeys('@supports (display: grid) { a { display: grid; } }'),
+    ).toEqual(['css.properties.display', 'css.properties.display.grid']);
+  });
+
+  it('maps descriptors through their containing at-rule', () => {
+    const css = [
+      '@font-face { font-display: swap; }',
+      '@property --brand { syntax: "<color>"; inherits: false; }',
+      '@counter-style thumbs { system: cyclic; }',
+      '@page { size: a4; }',
+      '@media (width > 1px) { a { display: grid; } }',
+    ].join('\n');
+
+    expect(detectKeys(css)).toEqual([
+      'css.at-rules.font-face.font-display',
+      'css.at-rules.property.syntax',
+      'css.at-rules.property.inherits',
+      'css.at-rules.counter-style.system',
+      'css.at-rules.page.size',
+      'css.properties.display',
+      'css.properties.display.grid',
+    ]);
+  });
+
+  it('distinguishes page descriptors from properties applied to a page', () => {
+    const detections = detectCSSFeatures([
+      {
+        css: '@page { size: a4; page-orientation: upright; margin: 1cm; color: black; }',
+        file: 'page.css',
+      },
+    ]);
+
+    expect(detections.map(({ type, bcdKey }) => [type, bcdKey])).toEqual([
+      ['descriptor', 'css.at-rules.page.size'],
+      ['descriptor', 'css.at-rules.page.page-orientation'],
+      ['property', 'css.properties.margin'],
+      ['property', 'css.properties.color'],
+      ['property-value', 'css.properties.color.black'],
+    ]);
+  });
+
+  it('does not treat named font feature values as properties', () => {
+    expect(
+      detectKeys('@font-feature-values Font { @styleset { nice: 1; } }'),
+    ).toEqual([]);
+  });
+
+  it('reports newer descriptor at-rules with their source locations', () => {
+    const detections = detectCSSFeatures([
+      {
+        css: [
+          '@font-palette-values --brand { base-palette: 1; }',
+          '@function --double(--value) { result: calc(var(--value) * 2); }',
+        ].join('\n'),
+        file: 'descriptors.css',
+      },
+    ]);
+
+    expect(detections).toEqual([
+      {
+        type: 'descriptor',
+        atRule: 'font-palette-values',
+        bcdKey: 'css.at-rules.font-palette-values.base-palette',
+        descriptor: 'base-palette',
+        source: { file: 'descriptors.css', line: 1 },
+      },
+      {
+        type: 'descriptor',
+        atRule: 'function',
+        bcdKey: 'css.at-rules.function.result',
+        descriptor: 'result',
+        source: { file: 'descriptors.css', line: 2 },
+      },
+    ]);
+  });
+
+  it('decodes escaped CSS identifiers before producing BCD keys', () => {
+    expect(detectKeys('a { d\\69 splay: g\\72 id; }')).toEqual([
+      'css.properties.display',
+      'css.properties.display.grid',
+    ]);
+  });
+
+  it('maps custom properties to their generic key and ignores vendor prefixes', () => {
+    expect(
+      detectKeys(
+        ':root { --columns: 3; -webkit-box-align: center; display: var(--display); }',
+      ),
+    ).toEqual([
+      'css.properties.custom-property',
+      'css.properties.display',
+    ]);
+  });
+
+  it('reports a property value on the line where its value starts', () => {
+    const detections = detectCSSFeatures([
+      { css: 'a {\n  color:\n    currentColor;\n}', file: 'multiline.css' },
+    ]);
+
+    expect(detections.map(detection => detection.source.line)).toEqual([2, 3]);
+  });
+
+  it('keeps separate occurrences of the same feature', () => {
+    const keys = detectKeys(
+      '.first { display: grid; }\n.second { display: grid; }',
+    );
+
+    expect(keys.filter(key => key === 'css.properties.display')).toHaveLength(2);
+  });
+
+  it('continues with other sources when one stylesheet contains malformed CSS', () => {
+    const detections = detectCSSFeatures([
+      { css: 'a { content: "unterminated; }', file: 'broken.css' },
+      { css: 'a { display: block; }', file: 'valid.css' },
+    ]);
+
+    expect(detections).toContainEqual({
+      type: 'property-value',
+      bcdKey: 'css.properties.display.block',
+      property: 'display',
+      value: 'block',
+      source: { file: 'valid.css', line: 1 },
+    });
+  });
+
+  it('returns no detections when there are no CSS sources', () => {
+    expect(detectCSSFeatures([])).toEqual([]);
+  });
+});

--- a/packages/telescope/package.json
+++ b/packages/telescope/package.json
@@ -66,6 +66,7 @@
   "devDependencies": {
     "@eslint/js": "^10.0.1",
     "@playwright/test": "^1.61.1",
+    "@types/css-tree": "^2.3.11",
     "@types/ejs": "^3.1.5",
     "@types/node": "^25.2.1",
     "@typescript-eslint/eslint-plugin": "^8.65.0",
@@ -83,6 +84,7 @@
     "@sitespeed.io/throttle": "^5.0.0",
     "adm-zip": "^0.6.0",
     "commander": "^10.0.0",
+    "css-tree": "^3.2.1",
     "ejs": "^6.0.1",
     "ffmpeg": "^0.0.4",
     "playwright": "^1.61.1",

--- a/packages/telescope/src/baselineCssBcd.ts
+++ b/packages/telescope/src/baselineCssBcd.ts
@@ -1,0 +1,37 @@
+/**
+ * CSS names that require special handling when constructing MDN Browser
+ * Compatibility Data keys.
+ */
+
+// Requiring a leading letter intentionally excludes vendor-prefixed identifiers.
+export const BCD_SEGMENT_PATTERN = /^[a-z][a-z0-9-]*$/i;
+
+export const CSS_WIDE_KEYWORDS: ReadonlySet<string> = new Set([
+  'inherit',
+  'initial',
+  'revert',
+  'revert-layer',
+  'unset',
+]);
+
+export const DESCRIPTOR_AT_RULES: ReadonlySet<string> = new Set([
+  'counter-style',
+  'font-face',
+  'font-palette-values',
+  'function',
+  'property',
+]);
+
+export const PAGE_DESCRIPTORS: ReadonlySet<string> = new Set([
+  'page-orientation',
+  'size',
+]);
+
+// BCD preserves canonical casing for this small set of CSS keyword segments.
+export const VALUE_CANONICAL_CASE: ReadonlyMap<string, string> = new Map([
+  ['currentcolor', 'currentColor'],
+  ['geometricprecision', 'geometricPrecision'],
+  ['linearrgb', 'linearRGB'],
+  ['nan', 'NaN'],
+  ['srgb', 'sRGB'],
+]);

--- a/packages/telescope/src/baselineCssDetect.ts
+++ b/packages/telescope/src/baselineCssDetect.ts
@@ -1,37 +1,18 @@
 import { generate, ident, parse, walk } from 'css-tree';
 
 import type { CssNode, WalkContext } from 'css-tree';
+import {
+  BCD_SEGMENT_PATTERN,
+  CSS_WIDE_KEYWORDS,
+  DESCRIPTOR_AT_RULES,
+  PAGE_DESCRIPTORS,
+  VALUE_CANONICAL_CASE,
+} from './baselineCssBcd.js';
 import type {
   CSSFeatureDetection,
   CSSFeatureSource,
   CSSSource,
 } from './types.js';
-
-// Requiring a leading letter intentionally excludes vendor-prefixed identifiers.
-const BCD_SEGMENT_PATTERN = /^[a-z][a-z0-9-]*$/i;
-const CSS_WIDE_KEYWORDS = new Set([
-  'inherit',
-  'initial',
-  'revert',
-  'revert-layer',
-  'unset',
-]);
-const DESCRIPTOR_AT_RULES = new Set([
-  'counter-style',
-  'font-face',
-  'font-palette-values',
-  'function',
-  'property',
-]);
-const PAGE_DESCRIPTORS = new Set(['page-orientation', 'size']);
-// BCD preserves canonical casing for this small set of CSS keyword segments.
-const VALUE_CANONICAL_CASE = new Map([
-  ['currentcolor', 'currentColor'],
-  ['geometricprecision', 'geometricPrecision'],
-  ['linearrgb', 'linearRGB'],
-  ['nan', 'NaN'],
-  ['srgb', 'sRGB'],
-]);
 
 /**
  * Detect CSS properties and keyword values that can map to MDN Browser
@@ -68,9 +49,13 @@ export function detectCSSFeatures(sources: CSSSource[]): CSSFeatureDetection[] {
           return;
         }
 
-        if (node.type !== 'Declaration' || this.atrulePrelude) return;
+        if (node.type !== 'Declaration' || this.atrulePrelude) {
+          return;
+        }
 
-        if (atRuleStack.includes('font-feature-values')) return;
+        if (atRuleStack.includes('font-feature-values')) {
+          return;
+        }
 
         const location = getSource(node, source.file);
         const decodedProperty = ident.decode(node.property);
@@ -85,7 +70,9 @@ export function detectCSSFeatures(sources: CSSSource[]): CSSFeatureDetection[] {
         }
 
         const property = normalizeName(decodedProperty);
-        if (!property) return;
+        if (!property) {
+          return;
+        }
 
         const parentAtRule = atRuleStack.at(-1);
         const isDescriptor =
@@ -111,7 +98,9 @@ export function detectCSSFeatures(sources: CSSSource[]): CSSFeatureDetection[] {
         });
 
         const value = normalizeValue(generate(node.value));
-        if (!value) return;
+        if (!value) {
+          return;
+        }
 
         detections.push({
           type: 'property-value',
@@ -124,7 +113,9 @@ export function detectCSSFeatures(sources: CSSSource[]): CSSFeatureDetection[] {
         });
       },
       leave(node: CssNode) {
-        if (node.type === 'Atrule') atRuleStack.pop();
+        if (node.type === 'Atrule') {
+          atRuleStack.pop();
+        }
       },
     });
   }
@@ -141,13 +132,17 @@ function getSource(node: CssNode, file: string): CSSFeatureSource {
 
 function normalizeName(name: string): string | null {
   const decodedName = ident.decode(name);
-  if (!BCD_SEGMENT_PATTERN.test(decodedName)) return null;
+  if (!BCD_SEGMENT_PATTERN.test(decodedName)) {
+    return null;
+  }
   return decodedName.toLowerCase();
 }
 
 function normalizeValue(value: string): string | null {
   const decodedValue = ident.decode(value.trim());
-  if (!BCD_SEGMENT_PATTERN.test(decodedValue)) return null;
+  if (!BCD_SEGMENT_PATTERN.test(decodedValue)) {
+    return null;
+  }
 
   const lowerCaseValue = decodedValue.toLowerCase();
   return VALUE_CANONICAL_CASE.get(lowerCaseValue) ?? lowerCaseValue;

--- a/packages/telescope/src/baselineCssDetect.ts
+++ b/packages/telescope/src/baselineCssDetect.ts
@@ -1,0 +1,154 @@
+import { generate, ident, parse, walk } from 'css-tree';
+
+import type { CssNode, WalkContext } from 'css-tree';
+import type {
+  CSSFeatureDetection,
+  CSSFeatureSource,
+  CSSSource,
+} from './types.js';
+
+const CSS_NAME_PATTERN = /^[a-z][a-z0-9-]*$/i;
+const CSS_VALUE_PATTERN = /^[a-z][a-z0-9-]*$/i;
+const CSS_WIDE_KEYWORDS = new Set([
+  'inherit',
+  'initial',
+  'revert',
+  'revert-layer',
+  'unset',
+]);
+const DESCRIPTOR_AT_RULES = new Set([
+  'counter-style',
+  'font-face',
+  'font-palette-values',
+  'function',
+  'property',
+]);
+const PAGE_DESCRIPTORS = new Set(['page-orientation', 'size']);
+// BCD preserves canonical casing for this small set of CSS keyword segments.
+const VALUE_CANONICAL_CASE = new Map([
+  ['currentcolor', 'currentColor'],
+  ['geometricprecision', 'geometricPrecision'],
+  ['linearrgb', 'linearRGB'],
+  ['nan', 'NaN'],
+  ['srgb', 'sRGB'],
+]);
+
+/**
+ * Detect CSS properties and keyword values that can map to MDN Browser
+ * Compatibility Data keys.
+ *
+ * Each syntax occurrence is retained so later analysis can aggregate its
+ * source locations. Candidate keys that are not represented by web-features
+ * are discarded by the separate Baseline status lookup stage.
+ *
+ * A stylesheet rejected by the parser is skipped without preventing other
+ * sources from being analyzed. Recoverable malformed CSS is parsed on a
+ * best-effort basis by css-tree.
+ *
+ * @param sources - CSS text and origin locations to analyze.
+ * @returns Detected properties and single-keyword values in stylesheet
+ *   traversal order.
+ */
+export function detectCSSFeatures(sources: CSSSource[]): CSSFeatureDetection[] {
+  const detections: CSSFeatureDetection[] = [];
+
+  for (const source of sources) {
+    const atRuleStack: string[] = [];
+    let ast: CssNode;
+    try {
+      ast = parse(source.css, { positions: true });
+    } catch {
+      continue;
+    }
+
+    walk(ast, {
+      enter(this: WalkContext, node: CssNode) {
+        if (node.type === 'Atrule') {
+          atRuleStack.push(normalizeName(node.name) ?? '');
+          return;
+        }
+
+        if (node.type !== 'Declaration' || this.atrulePrelude) return;
+
+        if (atRuleStack.includes('font-feature-values')) return;
+
+        const location = getSource(node, source.file);
+        const decodedProperty = ident.decode(node.property);
+        if (decodedProperty.startsWith('--')) {
+          detections.push({
+            type: 'property',
+            bcdKey: 'css.properties.custom-property',
+            property: decodedProperty,
+            source: location,
+          });
+          return;
+        }
+
+        const property = normalizeName(decodedProperty);
+        if (!property) return;
+
+        const parentAtRule = atRuleStack.at(-1);
+        const isDescriptor =
+          parentAtRule &&
+          (DESCRIPTOR_AT_RULES.has(parentAtRule) ||
+            (parentAtRule === 'page' && PAGE_DESCRIPTORS.has(property)));
+        if (isDescriptor) {
+          detections.push({
+            type: 'descriptor',
+            atRule: parentAtRule,
+            bcdKey: `css.at-rules.${parentAtRule}.${property}`,
+            descriptor: property,
+            source: location,
+          });
+          return;
+        }
+
+        detections.push({
+          type: 'property',
+          bcdKey: `css.properties.${property}`,
+          property,
+          source: location,
+        });
+
+        const value = normalizeValue(generate(node.value));
+        if (!value) return;
+
+        detections.push({
+          type: 'property-value',
+          bcdKey: CSS_WIDE_KEYWORDS.has(value)
+            ? `css.types.global_keywords.${value}`
+            : `css.properties.${property}.${value}`,
+          property,
+          source: getSource(node.value, source.file),
+          value,
+        });
+      },
+      leave(node: CssNode) {
+        if (node.type === 'Atrule') atRuleStack.pop();
+      },
+    });
+  }
+
+  return detections;
+}
+
+function getSource(node: CssNode, file: string): CSSFeatureSource {
+  return {
+    file,
+    line: node.loc?.start.line ?? 0,
+  };
+}
+
+function normalizeName(name: string): string | null {
+  const decodedName = ident.decode(name);
+  if (!CSS_NAME_PATTERN.test(decodedName)) return null;
+  return decodedName.toLowerCase();
+}
+
+function normalizeValue(value: string): string | null {
+  const decodedValue = ident.decode(value.trim());
+  if (!CSS_VALUE_PATTERN.test(decodedValue)) return null;
+
+  const lowerCaseValue = decodedValue.toLowerCase();
+  return VALUE_CANONICAL_CASE.get(lowerCaseValue) ?? lowerCaseValue;
+}

--- a/packages/telescope/src/baselineCssDetect.ts
+++ b/packages/telescope/src/baselineCssDetect.ts
@@ -7,8 +7,8 @@ import type {
   CSSSource,
 } from './types.js';
 
-const CSS_NAME_PATTERN = /^[a-z][a-z0-9-]*$/i;
-const CSS_VALUE_PATTERN = /^[a-z][a-z0-9-]*$/i;
+// Requiring a leading letter intentionally excludes vendor-prefixed identifiers.
+const BCD_SEGMENT_PATTERN = /^[a-z][a-z0-9-]*$/i;
 const CSS_WIDE_KEYWORDS = new Set([
   'inherit',
   'initial',
@@ -141,13 +141,13 @@ function getSource(node: CssNode, file: string): CSSFeatureSource {
 
 function normalizeName(name: string): string | null {
   const decodedName = ident.decode(name);
-  if (!CSS_NAME_PATTERN.test(decodedName)) return null;
+  if (!BCD_SEGMENT_PATTERN.test(decodedName)) return null;
   return decodedName.toLowerCase();
 }
 
 function normalizeValue(value: string): string | null {
   const decodedValue = ident.decode(value.trim());
-  if (!CSS_VALUE_PATTERN.test(decodedValue)) return null;
+  if (!BCD_SEGMENT_PATTERN.test(decodedValue)) return null;
 
   const lowerCaseValue = decodedValue.toLowerCase();
   return VALUE_CANONICAL_CASE.get(lowerCaseValue) ?? lowerCaseValue;

--- a/packages/telescope/src/types.ts
+++ b/packages/telescope/src/types.ts
@@ -643,6 +643,44 @@ export interface HarData {
 // Baseline Types
 // ============================================================================
 
+/** A CSS syntax occurrence that can be resolved against Baseline data. */
+export type CSSFeatureDetection =
+  | CSSDescriptorDetection
+  | CSSPropertyDetection
+  | CSSPropertyValueDetection;
+
+/** A descriptor mapped through the at-rule that defines its BCD namespace. */
+export interface CSSDescriptorDetection {
+  type: 'descriptor';
+  atRule: string;
+  bcdKey: string;
+  descriptor: string;
+  source: CSSFeatureSource;
+}
+
+/** Location where a CSS feature occurs. */
+export interface CSSFeatureSource {
+  file: string;
+  line: number;
+}
+
+/** A CSS property mapped to its candidate BCD key. */
+export interface CSSPropertyDetection {
+  type: 'property';
+  bcdKey: string;
+  property: string;
+  source: CSSFeatureSource;
+}
+
+/** A CSS property-value pair mapped to its candidate BCD key. */
+export interface CSSPropertyValueDetection {
+  type: 'property-value';
+  bcdKey: string;
+  property: string;
+  source: CSSFeatureSource;
+  value: string;
+}
+
 /**
  * A block of CSS extracted from a HAR, with its origin location.
  */

--- a/packages/telescope/src/types.ts
+++ b/packages/telescope/src/types.ts
@@ -681,6 +681,8 @@ export interface CSSPropertyValueDetection {
   property: string;
   source: CSSFeatureSource;
   value: string;
+}
+
 export type JSONPrimitive = boolean | number | string | null;
 export type JSONValue =
   | JSONPrimitive


### PR DESCRIPTION
Second slice of the `--baseline` CSS analysis feature, following #317. This PR adds detection of CSS declaration features from the previously extracted `CSSSource` objects.

The detector is intentionally **not wired into the CLI or `launchTest`** yet. At-rule occurrence detection, selector detection, Baseline status lookup, and pipeline integration follow in later PRs. Keeping declaration detection separate limits this PR to one independently tested parsing concern.

## Changes

### `detectCSSFeatures(sources): CSSFeatureDetection[]` (`src/baselineCssDetect.ts`)

Parses CSS with `css-tree` and produces candidate MDN Browser Compatibility Data keys for declaration syntax:

- Detects CSS properties as `css.properties.<property>`.
- Detects single-identifier property values when they can map to property-specific BCD keys.
- Maps CSS-wide keywords such as `revert-layer` through `css.types.global_keywords`.
- Maps custom properties to the generic `css.properties.custom-property` key.
- Maps descriptors through their containing at-rule, including:
  - `@font-face`
  - `@font-palette-values`
  - `@counter-style`
  - `@property`
  - `@function`
  - `@page`
- Distinguishes the `size` and `page-orientation` descriptors from ordinary properties applied within `@page`.
- Normalizes case and escaped CSS identifiers while preserving canonical BCD casing where required.
- Preserves individual occurrences and source lines for later aggregation.
- Reports multiline property values at the line where the value begins.
- Excludes declarations used only as conditional-query operands, such as `@supports (display: grid)`.
- Skips vendor-prefixed declarations and custom names inside `@font-feature-values`.
- Continues processing other stylesheets if one source cannot be parsed; recoverable malformed CSS is handled on a best-effort basis.

Candidate keys are intentionally not validated against `web-features` in this layer. Keys without a corresponding feature will be discarded by the later Baseline lookup stage.

### Types (`src/types.ts`)

Adds a discriminated union for declaration detections:

- `CSSPropertyDetection`
- `CSSPropertyValueDetection`
- `CSSDescriptorDetection`
- `CSSFeatureSource`
- `CSSFeatureDetection`

### Dependencies

Adds `css-tree` for standards-aware CSS parsing, traversal, identifier decoding, and source positions, along with its TypeScript definitions.

## Tests

Adds `packages/telescope/__tests__/baselineCssDetect.test.ts` with 19 pure unit tests covering:

- Property and single-keyword value detection
- Source file and line attribution
- Case normalization and escaped identifiers
- Canonical BCD key casing
- CSS-wide keywords
- Custom and vendor-prefixed properties
- Descriptor namespaces and `@page` classification
- Conditional-query operands
- Repeated feature occurrences
- Malformed stylesheets and empty input
