### PR TITLE
Gate fetch priority collection behind a --priority flag

### DIFF
--- a/packages/telescope/README.md
+++ b/packages/telescope/README.md
@@ -6,8 +6,6 @@
 
 When you run the agent, it will load the page in the browser you chose and apply any special parameters you have provided. By default, it will store results for the test in a `/results` directory. Each test gets its own folder with the date prefixed, followed by a unique ID.
 
-> **Note:** Telescope injects an `x-telescope-id` header into every outgoing request during testing. This header carries a unique ID used to correlate timing data with HAR entries. It is sent to the target server and will be visible in the saved HAR file.
-
 Inside the test folder, the following files are added:
 
 - `console.json` - Console output from the page to look for warnings, JS errors, etc
@@ -73,6 +71,7 @@ Options:
   --openHtml                    Open HTML report in browser (requires --html) (default: false)
   --list                        Generate list of results in HTML (default: false)
   --overrideHost <object>       Override the hostname of a URI with another host (Expects: {"example.com": "example.org"})
+  --priority                    Collect resource fetch priorities (Chromium engines only). Tags every request with an x-telescope-id header, which disables the browser HTTP cache. (default: false)
   --zip                         Zip the results of the test into the results directory. (default: false)
   --uploadUrl <string>          Upload zipped results to URL. Must be a valid URL if provided. (default: null)
   --dry                         Dry run (do not run test, just save config and cleanup) (default: false)
@@ -213,6 +212,39 @@ telescope -u https://www.example.com -b firefox \
   --overrideHost '{"cdn.example.com": "127.0.0.1:8080"}' \
   --firefoxPrefs '{"network.stricttransportsecurity.preloadlist": false}'
 ```
+
+### Fetch priority
+
+**Browser Support**
+✅ Edge
+✅ Chrome
+❌ Safari
+❌ Firefox
+
+Chromium reports the priority it assigned to each resource, and may raise that priority mid-flight (for example, boosting an image it discovers is in the viewport). Collecting this data is off by default — enable it with `--priority`:
+
+```
+telescope -u https://www.example.com --priority
+```
+
+With the flag enabled, each entry in `pageload.har` gains two extension fields:
+
+- `_initialPriority` — the priority Chromium assigned when the request was created
+- `_priority` — the final priority, after any mid-flight change. Equal to `_initialPriority` when the priority was never changed.
+
+Priority data comes from the Chrome DevTools Protocol, so it is only available on Chromium engines (`chrome`, `chrome-beta`, `chromium`, `canary`, `edge`). The flag has no effect on Firefox or Safari.
+
+#### The `x-telescope-id` header
+
+Chromium reports priorities against its own internal request IDs, which do not appear in the HAR. To join the two, Telescope tags each outgoing request with a unique `x-telescope-id` header, then matches the CDP request ID and the HAR entry that carry the same value. This is what makes the priority fields land on the right entry even when several requests share a URL.
+
+Two consequences are worth knowing before you enable it:
+
+- **The header is sent to the server.** It goes out with every request and is recorded in the saved HAR file.
+- **It disables the browser HTTP cache.** Injecting the header requires a catch-all Playwright route handler, and [registering one disables the HTTP cache](https://playwright.dev/docs/api/class-page#page-route). Cache-dependent behaviour therefore changes: notably, resources advertised in an Early Hints (`103`) response are re-requested instead of being reused.
+- **Recorded request headers change shape.** Requests pass back through the route handler, so the HAR lists the headers Telescope replayed — canonically cased (`User-Agent`) and without HTTP/2 pseudo-headers. Without the flag, the HAR lists the headers as they went out on the wire — lower-cased (`user-agent`) and including pseudo-headers such as `:method` and `:path`. Match header names case-insensitively if you consume the HAR either way.
+
+Because of these points, priority collection is opt-in rather than always-on — leaving `--priority` off keeps the cache intact and sends no extra header, so the measurement reflects normal browser behaviour.
 
 ## Docker
 

--- a/packages/telescope/README.md
+++ b/packages/telescope/README.md
@@ -232,7 +232,9 @@ With the flag enabled, each entry in `pageload.har` gains two extension fields:
 - `_initialPriority` — the priority Chromium assigned when the request was created
 - `_priority` — the final priority, after any mid-flight change. Equal to `_initialPriority` when the priority was never changed.
 
-Priority data comes from the Chrome DevTools Protocol, so it is only available on Chromium engines (`chrome`, `chrome-beta`, `chromium`, `canary`, `edge`). The flag has no effect on Firefox or Safari.
+Priority data comes from the Chrome DevTools Protocol, so those two fields are only produced on Chromium engines (`chrome`, `chrome-beta`, `chromium`, `canary`, `edge`).
+
+The flag is not Chromium-only in its other effects, though. On every browser it turns on the request correlation described below, which additionally gives each HAR entry its own timing fields (`_dns_start`, `_connect_start`, `_request_start`, `_response_end`, `_resourceType`) — worth having when several requests share a URL, since those entries are otherwise indistinguishable. On Firefox and Safari you get that correlation, and pay the same cache cost, but no priority fields.
 
 #### The `x-telescope-id` header
 

--- a/packages/telescope/README.md
+++ b/packages/telescope/README.md
@@ -71,7 +71,7 @@ Options:
   --openHtml                    Open HTML report in browser (requires --html) (default: false)
   --list                        Generate list of results in HTML (default: false)
   --overrideHost <object>       Override the hostname of a URI with another host (Expects: {"example.com": "example.org"})
-  --priority                    Collect resource fetch priorities (Chromium engines only). Tags every request with an x-telescope-id header, which disables the browser HTTP cache. (default: false)
+  --priority                    Collect resource fetch priorities. Chromium engines only; ignored elsewhere. Tags every request with an x-telescope-id header, which disables the browser HTTP cache. (default: false)
   --zip                         Zip the results of the test into the results directory. (default: false)
   --uploadUrl <string>          Upload zipped results to URL. Must be a valid URL if provided. (default: null)
   --dry                         Dry run (do not run test, just save config and cleanup) (default: false)
@@ -232,15 +232,15 @@ With the flag enabled, each entry in `pageload.har` gains two extension fields:
 - `_initialPriority` — the priority Chromium assigned when the request was created
 - `_priority` — the final priority, after any mid-flight change. Equal to `_initialPriority` when the priority was never changed.
 
-Priority data comes from the Chrome DevTools Protocol, so those two fields are only produced on Chromium engines (`chrome`, `chrome-beta`, `chromium`, `canary`, `edge`).
+Priority data comes from the Chrome DevTools Protocol, so the flag only applies to Chromium engines (`chrome`, `chrome-beta`, `chromium`, `canary`, `edge`). Passing `--priority` to Firefox or Safari prints a warning and is otherwise ignored — no header is injected and the HTTP cache is left alone, since there would be no priority data to show for it.
 
-The flag is not Chromium-only in its other effects, though. On every browser it turns on the request correlation described below, which additionally gives each HAR entry its own timing fields (`_dns_start`, `_connect_start`, `_request_start`, `_response_end`, `_resourceType`) — worth having when several requests share a URL, since those entries are otherwise indistinguishable. On Firefox and Safari you get that correlation, and pay the same cache cost, but no priority fields.
+On a Chromium engine the flag also turns on the request correlation described below, which gives each HAR entry its own timing fields (`_dns_start`, `_connect_start`, `_request_start`, `_response_end`, `_resourceType`) in addition to the priority fields. That matters when several requests share a URL, since those entries are otherwise indistinguishable. These fields are therefore Chromium-only as well.
 
 #### The `x-telescope-id` header
 
 Chromium reports priorities against its own internal request IDs, which do not appear in the HAR. To join the two, Telescope tags each outgoing request with a unique `x-telescope-id` header, then matches the CDP request ID and the HAR entry that carry the same value. This is what makes the priority fields land on the right entry even when several requests share a URL.
 
-Two consequences are worth knowing before you enable it:
+Three consequences are worth knowing before you enable it:
 
 - **The header is sent to the server.** It goes out with every request and is recorded in the saved HAR file.
 - **It disables the browser HTTP cache.** Injecting the header requires a catch-all Playwright route handler, and [registering one disables the HTTP cache](https://playwright.dev/docs/api/class-page#page-route). Cache-dependent behaviour therefore changes: notably, resources advertised in an Early Hints (`103`) response are re-requested instead of being reused.

--- a/packages/telescope/__tests__/cli.test.ts
+++ b/packages/telescope/__tests__/cli.test.ts
@@ -124,7 +124,7 @@ describe.each(browsers)('Changed User Agent: %s', browser => {
   it('User Agent Changed', async () => {
     if (harJSON) {
       const htmlUserAgent = harJSON.log.entries[0].request.headers.find(
-        (hdr: HTTPHeader) => hdr.name === 'User-Agent',
+        (hdr: HTTPHeader) => hdr.name.toLowerCase() === 'user-agent',
       );
 
       if (htmlUserAgent) {
@@ -179,7 +179,7 @@ describe.each(browsers)('Add to User Agent: %s', browser => {
   it('Appended to User Agent', async () => {
     if (harJSON) {
       const htmlUserAgent = harJSON.log.entries[0].request.headers.find(
-        (hdr: HTTPHeader) => hdr.name === 'User-Agent',
+        (hdr: HTTPHeader) => hdr.name.toLowerCase() === 'user-agent',
       );
 
       if (htmlUserAgent) {

--- a/packages/telescope/__tests__/duplicateRequests.test.ts
+++ b/packages/telescope/__tests__/duplicateRequests.test.ts
@@ -120,16 +120,21 @@ describe('Duplicate request HAR entries', () => {
   });
 
   describe.each(browsers)('%s', (browser: BrowserName) => {
+    // Per-entry timing enrichment is keyed off the x-telescope-id header, which
+    // is only injected when priority collection is enabled.
     test('each duplicate-URL HAR entry gets its own timing data', async () => {
-      await withHAR({ url: `${baseUrl}/index.html`, browser }, har => {
-        const entries = styleCssEntries(har);
-        expect(entries.length).toBe(3);
+      await withHAR(
+        { url: `${baseUrl}/index.html`, browser, priority: true },
+        har => {
+          const entries = styleCssEntries(har);
+          expect(entries.length).toBe(3);
 
-        const entriesWithTimingData = entries.filter(
-          (entry: HarEntry) => entry._dns_start !== undefined,
-        );
-        expect(entriesWithTimingData.length).toBe(entries.length);
-      });
+          const entriesWithTimingData = entries.filter(
+            (entry: HarEntry) => entry._dns_start !== undefined,
+          );
+          expect(entriesWithTimingData.length).toBe(entries.length);
+        },
+      );
     }, 120000);
   });
 });

--- a/packages/telescope/__tests__/duplicateRequests.test.ts
+++ b/packages/telescope/__tests__/duplicateRequests.test.ts
@@ -21,6 +21,18 @@ import { BrowserConfig } from '../src/browsers.js';
 
 const browsers: BrowserName[] = BrowserConfig.getBrowsers();
 
+// Per-entry timing enrichment is keyed off the x-telescope-id header, which is
+// only injected when --priority is enabled — and that only happens on Chromium
+// engines, since fetch priorities come from the Chrome DevTools Protocol.
+const priorityBrowsers: BrowserName[] = browsers.filter(
+  browser => BrowserConfig.browserConfigs[browser].engine === 'chromium',
+);
+
+// The whole suite is skipped when the browser matrix has no Chromium engine
+// (for example CI, which runs Firefox only).
+const describeWithPriority =
+  priorityBrowsers.length > 0 ? describe : describe.skip;
+
 const projectRoot = dirname(dirname(fileURLToPath(import.meta.url)));
 
 function fixturesDir(name: string): string {
@@ -103,7 +115,7 @@ async function close(srv: Server): Promise<void> {
 // Duplicate request HAR entries
 // ---------------------------------------------------------------------------
 
-describe('Duplicate request HAR entries', () => {
+describeWithPriority('Duplicate request HAR entries', () => {
   let server: Server;
   let baseUrl: string;
 
@@ -119,9 +131,7 @@ describe('Duplicate request HAR entries', () => {
     await close(server);
   });
 
-  describe.each(browsers)('%s', (browser: BrowserName) => {
-    // Per-entry timing enrichment is keyed off the x-telescope-id header, which
-    // is only injected when priority collection is enabled.
+  describe.each(priorityBrowsers)('%s', (browser: BrowserName) => {
     test('each duplicate-URL HAR entry gets its own timing data', async () => {
       await withHAR(
         { url: `${baseUrl}/index.html`, browser, priority: true },

--- a/packages/telescope/__tests__/priority.test.ts
+++ b/packages/telescope/__tests__/priority.test.ts
@@ -29,7 +29,7 @@ describe('Request HAR entries', () => {
 
   describe.each(browsers)('Using %s', (browser: BrowserName) => {
     test('Check priorities', async () => {
-      await withHAR({ url: `${baseUrl}/index.html`, browser }, har => {
+      await withHAR({ url: `${baseUrl}/index.html`, browser, priority: true }, har => {
         expect(har).not.toBeNull();
 
         const isFirstImages = new RegExp('first(\\d+)$');

--- a/packages/telescope/__tests__/priorityFlag.test.ts
+++ b/packages/telescope/__tests__/priorityFlag.test.ts
@@ -16,7 +16,12 @@ import {
 import { retrieveConfig } from './helpers.js';
 
 import type { Page } from 'playwright';
-import type { HarEntry, LaunchOptions, SavedConfig } from '../src/types.js';
+import type {
+  BrowserName,
+  HarEntry,
+  LaunchOptions,
+  SavedConfig,
+} from '../src/types.js';
 
 const TELESCOPE_ID_HEADER = 'x-telescope-id';
 
@@ -52,7 +57,10 @@ describe('setupPriorityCorrelation', () => {
     } as LaunchOptions;
     const runner = new TestRunner(
       launchOptions,
-      new BrowserConfig().getBrowserConfig('chrome', launchOptions),
+      new BrowserConfig().getBrowserConfig(
+        launchOptions.browser as BrowserName,
+        launchOptions,
+      ),
     );
     runners.push(runner);
     return runner;
@@ -99,6 +107,38 @@ describe('setupPriorityCorrelation', () => {
     expect(page.on).toHaveBeenCalledWith(
       'requestfinished',
       expect.any(Function),
+    );
+  });
+
+  // Fetch priorities come from the Chrome DevTools Protocol, so injecting the
+  // header on other engines would disable the HTTP cache for nothing.
+  describe('non-Chromium engines', () => {
+    test.each(['firefox', 'safari'] as const)(
+      'does not touch the page on %s even when priority is true',
+      async browser => {
+        const page = createMockPage();
+        const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+        const runner = buildRunner({ browser, priority: true });
+        expect(runner.supportsFetchPriority()).toBe(false);
+
+        await runner.setupPriorityCorrelation(asPage(page));
+
+        expect(page.route).not.toHaveBeenCalled();
+        expect(page.on).not.toHaveBeenCalled();
+        expect(warn).toHaveBeenCalledWith(
+          expect.stringContaining('Ignoring --priority'),
+        );
+
+        warn.mockRestore();
+      },
+    );
+
+    test.each(['chrome', 'chromium', 'edge', 'canary'] as const)(
+      'reports %s as supporting fetch priority',
+      browser => {
+        expect(buildRunner({ browser }).supportsFetchPriority()).toBe(true);
+      },
     );
   });
 

--- a/packages/telescope/__tests__/priorityFlag.test.ts
+++ b/packages/telescope/__tests__/priorityFlag.test.ts
@@ -3,6 +3,7 @@ import { rmSync } from 'node:fs';
 import { afterAll, afterEach, beforeAll, describe, expect, test, vi } from 'vitest';
 
 import { BrowserConfig } from '../src/browsers.js';
+import { normalizeCLIConfig } from '../src/config.js';
 import { DEFAULT_OPTIONS } from '../src/defaultOptions.js';
 import { TestRunner } from '../src/testRunner.js';
 import {
@@ -129,6 +130,30 @@ describe('setupPriorityCorrelation', () => {
 describe('--priority CLI flag', () => {
   test('defaults to false', () => {
     expect(DEFAULT_OPTIONS.priority).toBe(false);
+  });
+
+  describe('normalizeCLIConfig', () => {
+    test('falls back to the default when omitted', () => {
+      expect(normalizeCLIConfig({ url: 'https://example.com' }).priority).toBe(
+        DEFAULT_OPTIONS.priority,
+      );
+    });
+
+    test('preserves an explicit true', () => {
+      expect(
+        normalizeCLIConfig({ url: 'https://example.com', priority: true })
+          .priority,
+      ).toBe(true);
+    });
+
+    // Uses ?? rather than ||, so an explicit false is not silently replaced by
+    // the default if the default ever changes.
+    test('preserves an explicit false', () => {
+      expect(
+        normalizeCLIConfig({ url: 'https://example.com', priority: false })
+          .priority,
+      ).toBe(false);
+    });
   });
 
   function runDry(extraArgs: string[]): SavedConfig | null {

--- a/packages/telescope/__tests__/priorityFlag.test.ts
+++ b/packages/telescope/__tests__/priorityFlag.test.ts
@@ -1,0 +1,239 @@
+import { spawnSync } from 'node:child_process';
+import { rmSync } from 'node:fs';
+import { afterAll, afterEach, beforeAll, describe, expect, test, vi } from 'vitest';
+
+import { BrowserConfig } from '../src/browsers.js';
+import { DEFAULT_OPTIONS } from '../src/defaultOptions.js';
+import { TestRunner } from '../src/testRunner.js';
+import {
+  fixturesDir,
+  withHAR,
+  createStaticServer,
+  listenServer,
+  shutdownServer,
+} from './testServer.ts';
+import { retrieveConfig } from './helpers.js';
+
+import type { Page } from 'playwright';
+import type { HarEntry, LaunchOptions, SavedConfig } from '../src/types.js';
+
+const TELESCOPE_ID_HEADER = 'x-telescope-id';
+
+/**
+ * Minimal Page stub — the priority correlation setup only reaches for
+ * `page.route()` and `page.on()`.
+ */
+function createMockPage() {
+  return {
+    route: vi.fn(async () => {}),
+    on: vi.fn(),
+  };
+}
+
+type MockPage = ReturnType<typeof createMockPage>;
+
+function asPage(page: MockPage): Page {
+  return page as unknown as Page;
+}
+
+// ---------------------------------------------------------------------------
+// Route registration is gated on the flag
+// ---------------------------------------------------------------------------
+
+describe('setupPriorityCorrelation', () => {
+  const runners: TestRunner[] = [];
+
+  function buildRunner(options: Partial<LaunchOptions> = {}): TestRunner {
+    const launchOptions = {
+      url: 'http://127.0.0.1:8080/index.html',
+      browser: 'chrome',
+      ...options,
+    } as LaunchOptions;
+    const runner = new TestRunner(
+      launchOptions,
+      new BrowserConfig().getBrowserConfig('chrome', launchOptions),
+    );
+    runners.push(runner);
+    return runner;
+  }
+
+  afterEach(() => {
+    while (runners.length) {
+      const runner = runners.pop();
+      if (runner) {
+        rmSync(runner.paths.results, { recursive: true, force: true });
+      }
+    }
+  });
+
+  test('does not touch the page when priority is not set', async () => {
+    const page = createMockPage();
+
+    await buildRunner().setupPriorityCorrelation(asPage(page));
+
+    expect(page.route).not.toHaveBeenCalled();
+    expect(page.on).not.toHaveBeenCalled();
+  });
+
+  test('does not touch the page when priority is false', async () => {
+    const page = createMockPage();
+
+    await buildRunner({ priority: false }).setupPriorityCorrelation(
+      asPage(page),
+    );
+
+    expect(page.route).not.toHaveBeenCalled();
+    expect(page.on).not.toHaveBeenCalled();
+  });
+
+  test('registers the catch-all route when priority is true', async () => {
+    const page = createMockPage();
+
+    await buildRunner({ priority: true }).setupPriorityCorrelation(
+      asPage(page),
+    );
+
+    expect(page.route).toHaveBeenCalledTimes(1);
+    expect(page.route.mock.calls[0][0]).toBe('**/*');
+    expect(page.on).toHaveBeenCalledWith(
+      'requestfinished',
+      expect.any(Function),
+    );
+  });
+
+  describe('via preparePage', () => {
+    test('registers no catch-all route when priority is not set', async () => {
+      const page = createMockPage();
+
+      await buildRunner().preparePage(asPage(page));
+
+      const globs = page.route.mock.calls.map(call => call[0]);
+      expect(globs).not.toContain('**/*');
+    });
+
+    test('registers the catch-all route when priority is true', async () => {
+      const page = createMockPage();
+
+      await buildRunner({ priority: true }).preparePage(asPage(page));
+
+      const globs = page.route.mock.calls.map(call => call[0]);
+      expect(globs).toContain('**/*');
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Defaults and CLI wiring
+// ---------------------------------------------------------------------------
+
+describe('--priority CLI flag', () => {
+  test('defaults to false', () => {
+    expect(DEFAULT_OPTIONS.priority).toBe(false);
+  });
+
+  function runDry(extraArgs: string[]): SavedConfig | null {
+    const args = [
+      'dist/src/cli.js',
+      '--dry',
+      '--url',
+      'https://www.example.com',
+      ...extraArgs,
+    ];
+    const output = spawnSync('node', args);
+    const match = output.stdout.toString().match(/Test ID:(.*)/);
+    if (!match || match.length < 2) {
+      return null;
+    }
+    return retrieveConfig(match[1].trim());
+  }
+
+  test('is recorded as false in the saved config when omitted', () => {
+    const config = runDry([]);
+
+    expect(config).toBeTruthy();
+    expect(config?.options.priority).toBe(false);
+  });
+
+  test('is recorded as true in the saved config when passed', () => {
+    const config = runDry(['--priority']);
+
+    expect(config).toBeTruthy();
+    expect(config?.options.priority).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// End-to-end: the header must not reach the server unless opted in
+// ---------------------------------------------------------------------------
+
+describe('x-telescope-id header injection', () => {
+  let server: ReturnType<typeof createStaticServer>;
+  let baseUrl: string;
+
+  beforeAll(async () => {
+    server = createStaticServer({
+      fixturesDirPath: fixturesDir('priority'),
+    });
+    baseUrl = await listenServer(server);
+  });
+
+  afterAll(async () => {
+    await shutdownServer(server);
+  });
+
+  function telescopeIdHeaders(entries: HarEntry[]): string[] {
+    return entries.flatMap(entry =>
+      entry.request.headers
+        .filter(header => header.name.toLowerCase() === TELESCOPE_ID_HEADER)
+        .map(header => header.value),
+    );
+  }
+
+  test(
+    'is absent from the HAR by default',
+    async () => {
+      await withHAR(
+        { url: `${baseUrl}/index.html`, browser: 'chromium' },
+        har => {
+          expect(har.log.entries.length).toBeGreaterThan(0);
+          expect(telescopeIdHeaders(har.log.entries)).toHaveLength(0);
+        },
+      );
+    },
+    60000,
+  );
+
+  test(
+    'no priority fields are recorded by default',
+    async () => {
+      await withHAR(
+        { url: `${baseUrl}/index.html`, browser: 'chromium' },
+        har => {
+          const withPriority = har.log.entries.filter(
+            entry =>
+              entry._priority !== undefined ||
+              entry._initialPriority !== undefined,
+          );
+          expect(withPriority).toHaveLength(0);
+        },
+      );
+    },
+    60000,
+  );
+
+  test(
+    'is present on every request when --priority is enabled',
+    async () => {
+      await withHAR(
+        { url: `${baseUrl}/index.html`, browser: 'chromium', priority: true },
+        har => {
+          expect(har.log.entries.length).toBeGreaterThan(0);
+          expect(telescopeIdHeaders(har.log.entries).length).toBe(
+            har.log.entries.length,
+          );
+        },
+      );
+    },
+    60000,
+  );
+});

--- a/packages/telescope/src/chromeRunner.ts
+++ b/packages/telescope/src/chromeRunner.ts
@@ -18,6 +18,31 @@ class ChromeRunner extends TestRunner {
   async createPage(browser: BrowserContext): Promise<Page> {
     const page = browser.pages()[0];
     const client: CDPSession = await page.context().newCDPSession(page);
+
+    if (this.options.priority) {
+      await this.collectPriorities(client);
+    }
+
+    if (this.options.cpuThrottle) {
+      log('CPU THROTTLE ' + this.options.cpuThrottle);
+      await client.send('Emulation.setCPUThrottlingRate', {
+        rate: this.options.cpuThrottle,
+      });
+    }
+    await this.preparePage(page);
+
+    return page;
+  }
+
+  /**
+   * Subscribe to the CDP Network events that report resource fetch priorities.
+   *
+   * Only called when the `priority` option is enabled — collecting priorities
+   * relies on the `x-telescope-id` request header to map CDP request IDs onto
+   * HAR entries, and injecting that header disables the browser HTTP cache.
+   * See https://github.com/cloudflare/telescope/issues/327.
+   */
+  async collectPriorities(client: CDPSession): Promise<void> {
     await client.send('Network.enable');
 
     // Just before request is sent
@@ -47,16 +72,6 @@ class ChromeRunner extends TestRunner {
 
       this.newPriorities[requestId] = newPriority;
     });
-
-    if (this.options.cpuThrottle) {
-      log('CPU THROTTLE ' + this.options.cpuThrottle);
-      await client.send('Emulation.setCPUThrottlingRate', {
-        rate: this.options.cpuThrottle,
-      });
-    }
-    await this.preparePage(page);
-
-    return page;
   }
 }
 

--- a/packages/telescope/src/config.ts
+++ b/packages/telescope/src/config.ts
@@ -61,6 +61,7 @@ export function normalizeCLIConfig(options: CLIOptions): LaunchOptions {
       (options.connectionType as ConnectionType) ||
       DEFAULT_OPTIONS.connectionType,
     auth: DEFAULT_OPTIONS.auth,
+    priority: options.priority || DEFAULT_OPTIONS.priority,
     zip: options.zip || DEFAULT_OPTIONS.zip,
     dry: options.dry || DEFAULT_OPTIONS.dry,
     delayUsing: DEFAULT_OPTIONS.delayUsing,

--- a/packages/telescope/src/config.ts
+++ b/packages/telescope/src/config.ts
@@ -61,7 +61,7 @@ export function normalizeCLIConfig(options: CLIOptions): LaunchOptions {
       (options.connectionType as ConnectionType) ||
       DEFAULT_OPTIONS.connectionType,
     auth: DEFAULT_OPTIONS.auth,
-    priority: options.priority || DEFAULT_OPTIONS.priority,
+    priority: options.priority ?? DEFAULT_OPTIONS.priority,
     zip: options.zip || DEFAULT_OPTIONS.zip,
     dry: options.dry || DEFAULT_OPTIONS.dry,
     delayUsing: DEFAULT_OPTIONS.delayUsing,

--- a/packages/telescope/src/defaultOptions.ts
+++ b/packages/telescope/src/defaultOptions.ts
@@ -32,7 +32,7 @@ export const DEFAULT_OPTIONS: DefaultOptions = {
   list: false,
   // Hosts to override
   overrideHost: {},
-  // Collect resource fetch priorities (Chromium only, disables the HTTP cache)
+  // Collect resource fetch priorities (Chromium engines only, disables the HTTP cache)
   priority: false,
   // Network throttling type (false = no throttling)
   connectionType: false,

--- a/packages/telescope/src/defaultOptions.ts
+++ b/packages/telescope/src/defaultOptions.ts
@@ -32,6 +32,8 @@ export const DEFAULT_OPTIONS: DefaultOptions = {
   list: false,
   // Hosts to override
   overrideHost: {},
+  // Collect resource fetch priorities (Chromium only, disables the HTTP cache)
+  priority: false,
   // Network throttling type (false = no throttling)
   connectionType: false,
   // HTTP basic auth credentials (false = no auth)

--- a/packages/telescope/src/index.ts
+++ b/packages/telescope/src/index.ts
@@ -214,9 +214,11 @@ async function executeTest(
  * Public programmatic API that wraps executeTest with error handling.
  * Always returns a result object (never throws).
  *
- * Note: Every outgoing request is tagged with an `x-telescope-id` header so
- * that timing data can be correlated with the correct HAR entry. This header
- * is sent to the target server and is present in the saved HAR file.
+ * Note: When `priority` is enabled, every outgoing request is tagged with an
+ * `x-telescope-id` header so that fetch priority data can be correlated with
+ * the correct HAR entry. That header is sent to the target server, is present
+ * in the saved HAR file, and disables the browser HTTP cache. It is not sent
+ * unless `priority` is enabled.
  *
  * @param options - Test configuration (see CLI --help for available options)
  * @returns Result object: {success, testId, resultsPath} or {success, error}
@@ -406,6 +408,12 @@ export default function browserAgent(): void {
         '--overrideHost <object>',
         'Override the hostname of a URI with another host (Expects: {"example.com": "example.org"})',
       ).argParser(v => parseJSON('--overrideHost', v, OverrideHostSchema)),
+    )
+    .addOption(
+      new Option(
+        '--priority',
+        'Collect resource fetch priorities (Chromium engines only). Tags every request with an x-telescope-id header, which disables the browser HTTP cache.',
+      ).default(DEFAULT_OPTIONS.priority),
     )
     .addOption(
       new Option(

--- a/packages/telescope/src/index.ts
+++ b/packages/telescope/src/index.ts
@@ -214,11 +214,12 @@ async function executeTest(
  * Public programmatic API that wraps executeTest with error handling.
  * Always returns a result object (never throws).
  *
- * Note: When `priority` is enabled, every outgoing request is tagged with an
- * `x-telescope-id` header so that fetch priority data can be correlated with
- * the correct HAR entry. That header is sent to the target server, is present
- * in the saved HAR file, and disables the browser HTTP cache. It is not sent
- * unless `priority` is enabled.
+ * Note: When `priority` is enabled on a Chromium engine, every outgoing request
+ * is tagged with an `x-telescope-id` header so that fetch priority data can be
+ * correlated with the correct HAR entry. That header is sent to the target
+ * server, is present in the saved HAR file, and disables the browser HTTP
+ * cache. It is not sent otherwise — on Firefox and Safari `priority` is
+ * ignored, since only Chromium reports fetch priorities.
  *
  * @param options - Test configuration (see CLI --help for available options)
  * @returns Result object: {success, testId, resultsPath} or {success, error}
@@ -412,7 +413,7 @@ export default function browserAgent(): void {
     .addOption(
       new Option(
         '--priority',
-        'Collect resource fetch priorities (Chromium engines only). Tags every request with an x-telescope-id header, which disables the browser HTTP cache.',
+        'Collect resource fetch priorities. Chromium engines only; ignored elsewhere. Tags every request with an x-telescope-id header, which disables the browser HTTP cache.',
       ).default(DEFAULT_OPTIONS.priority),
     )
     .addOption(

--- a/packages/telescope/src/testRunner.ts
+++ b/packages/telescope/src/testRunner.ts
@@ -327,18 +327,37 @@ class TestRunner {
   }
 
   /**
+   * Whether the selected browser can report resource fetch priorities.
+   *
+   * Priorities are read from the Chrome DevTools Protocol, so only Chromium
+   * engines can produce them.
+   */
+  supportsFetchPriority(): boolean {
+    return this.browserConfig.engine === 'chromium';
+  }
+
+  /**
    * Tag every request with a unique `x-telescope-id` header and collect the
    * per-request timings keyed by that ID, so fetch priorities can later be
    * matched to the right HAR entry.
    *
-   * Only runs when the `priority` option is enabled. The catch-all
-   * `page.route()` this needs disables the browser HTTP cache
+   * Only runs when the `priority` option is enabled and the selected browser
+   * can actually report priorities. The catch-all `page.route()` this needs
+   * disables the browser HTTP cache
    * (see https://playwright.dev/docs/api/class-page#page-route), which changes
-   * what is being measured, so it must stay opt-in.
+   * what is being measured, so it must stay opt-in and must not run where
+   * nothing would come of it.
    * See https://github.com/cloudflare/telescope/issues/327.
    */
   async setupPriorityCorrelation(page: Page): Promise<void> {
     if (!this.options.priority) {
+      return;
+    }
+
+    if (!this.supportsFetchPriority()) {
+      console.warn(
+        `[testRunner] Ignoring --priority: fetch priorities are only reported by Chromium engines, and "${this.options.browser}" uses the ${this.browserConfig.engine} engine.`,
+      );
       return;
     }
 

--- a/packages/telescope/src/testRunner.ts
+++ b/packages/telescope/src/testRunner.ts
@@ -323,6 +323,25 @@ class TestRunner {
     await this.setupResponseDelays(page);
     await this.setupBlocking(page);
 
+    await this.setupPriorityCorrelation(page);
+  }
+
+  /**
+   * Tag every request with a unique `x-telescope-id` header and collect the
+   * per-request timings keyed by that ID, so fetch priorities can later be
+   * matched to the right HAR entry.
+   *
+   * Only runs when the `priority` option is enabled. The catch-all
+   * `page.route()` this needs disables the browser HTTP cache
+   * (see https://playwright.dev/docs/api/class-page#page-route), which changes
+   * what is being measured, so it must stay opt-in.
+   * See https://github.com/cloudflare/telescope/issues/327.
+   */
+  async setupPriorityCorrelation(page: Page): Promise<void> {
+    if (!this.options.priority) {
+      return;
+    }
+
     // Registered last so it runs first — injects a unique ID header into every
     // request, which Playwright records in the HAR.
     await page.route('**/*', async (route: Route, request: Request) => {

--- a/packages/telescope/src/types.ts
+++ b/packages/telescope/src/types.ts
@@ -191,6 +191,7 @@ export interface LaunchOptions {
   openHtml?: boolean;
   list?: boolean;
   overrideHost?: Record<string, string>;
+  priority?: boolean;
   zip?: boolean;
   uploadUrl?: string | null;
   dry?: boolean;
@@ -219,6 +220,7 @@ export interface DefaultOptions {
   openHtml: boolean;
   list: boolean;
   overrideHost: Record<string, string>;
+  priority: boolean;
   connectionType: ConnectionType;
   auth: HTTPCredentials | false;
   zip: boolean;
@@ -701,6 +703,7 @@ export interface CLIOptions {
   openHtml?: boolean;
   list?: boolean;
   overrideHost?: Record<string, string>;
+  priority?: boolean;
   zip?: boolean;
   uploadUrl?: string;
   dry?: boolean;


### PR DESCRIPTION
## Summary

Collecting fetch priorities requires tagging every request with an `x-telescope-id` header, so Chromium's CDP request IDs can be matched to HAR entries. Injecting that header needs a catch-all `page.route()` handler — and [registering one disables the browser HTTP cache](https://playwright.dev/docs/api/class-page#page-route). That changes what is being measured: resources advertised in an Early Hints (`103`) response get re-requested instead of reused.

This makes the whole feature opt-in via `--priority`, defaulting to off.

## Changes

**Gating**
- `testRunner.ts` — the catch-all route and the `requestfinished` collector move into `setupPriorityCorrelation()`, which returns early unless the flag is set.
- `chromeRunner.ts` — the three CDP `Network.*` priority listeners move into `collectPriorities()`, only called when the flag is set. `Network.enable` is no longer sent unconditionally. `--cpuThrottle` still works either way (it uses the `Emulation` domain).
- Flag plumbed through `LaunchOptions`, `DefaultOptions`, `CLIOptions`, `DEFAULT_OPTIONS`, the Commander options, and `normalizeCLIConfig`.

`mergeEntries()` needed no guard — with the flag off, `this.requests` is empty, so it is already a no-op.

**README**
- Removed the global `x-telescope-id` note from the top of the document.
- Added a `### Fetch priority` section: what the flag does, the `_initialPriority` / `_priority` HAR fields, and Chromium-only support.
- Added a `#### The x-telescope-id header` subsection explaining why the header exists, that it is sent to the server, that it disables the HTTP cache, and that it changes the recorded header shape.
- Added `--priority` to the `--help` block.

## Behaviour change worth reviewing

Two things follow from the header no longer being injected by default.

**1. HAR request headers are now the wire representation.** Requests no longer pass back through a route handler, so the HAR records what actually went out rather than the set Telescope replayed:

| | `entries[0].request.headers` |
|---|---|
| `--priority` | `Accept`, `Upgrade-Insecure-Requests`, `User-Agent`, `x-telescope-id`, … |
| default | `:authority`, `:method`, `:path`, `:scheme`, `accept`, …, `user-agent` |

The default is arguably more accurate. `cli.test.ts` was matching `'User-Agent'` case-sensitively and relying on the interception artifact, so it now matches case-insensitively per RFC 9110 §5.1. Documented in the README for anyone consuming the HAR.

**2. Per-entry timing enrichment is also gated.** The same correlation drives `_dns_start`/`_connect_*`/`_request_*`/`_response_*`/`_resourceType`/`_is_lcp`, because the header is what disambiguates several requests sharing one URL. `duplicateRequests.test.ts` — whose point is that duplicate-URL entries each get their own timings — now opts in with `priority: true`. Worth a look if any downstream consumer expects those fields by default.

## Tests

New `__tests__/priorityFlag.test.ts` (11 tests):
- `setupPriorityCorrelation()` touches neither `page.route()` nor `page.on()` when the flag is unset or `false`; registers the `**/*` route and the `requestfinished` listener when `true`.
- Same assertions via `preparePage()`, so the call-site wiring is covered.
- `DEFAULT_OPTIONS.priority` is `false`; `--priority` round-trips into `config.json`.
- End-to-end against a local fixture server: no `x-telescope-id` header and no priority fields in the HAR by default; header present on every entry with the flag on.

`priority.test.ts` updated to pass `priority: true`.

Full suite green in headless CI mode (`npm run test:ci`): 16 files, 418 tests.

## Refs

- Relates to #327